### PR TITLE
feat(TCOMP-681): add dummy schema property

### DIFF
--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ElementParameterCreator.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/ElementParameterCreator.java
@@ -71,7 +71,7 @@ public class ElementParameterCreator {
                     PropertyDefinitionDecorator.wrap(detail.getProperties());
             PropertyNode root = PropertyNodeUtils.createPropertyTree(properties);
             // add main parameters
-            SettingsCreator mainCreator = new SettingsCreator(node, EComponentCategory.BASIC);
+            SettingsCreator mainCreator = new SchemaSettingsCreator(node, EComponentCategory.BASIC);
             root.accept(mainCreator, Metadatas.MAIN_FORM);
             parameters.addAll(mainCreator.getSettings());
             // add advanced parameters

--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SchemaSettingsCreator.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SchemaSettingsCreator.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.talend.sdk.component.studio.model.parameter;
+
+import org.talend.core.model.process.EComponentCategory;
+import org.talend.core.model.process.EConnectionType;
+import org.talend.core.model.process.EParameterFieldType;
+import org.talend.core.model.process.IElement;
+import org.talend.designer.core.model.components.EParameterName;
+import org.talend.designer.core.model.components.ElementParameter;
+import org.talend.sdk.component.studio.metadata.TaCoKitElementParameter;
+
+/**
+ * Adds schema property on Basic view in the 1st row by default
+ */
+public class SchemaSettingsCreator extends SettingsCreator {
+
+    /**
+     * Creates instance and adds schema property
+     * 
+     * @param iNode
+     * @param category
+     */
+    public SchemaSettingsCreator(final IElement iNode, final EComponentCategory category) {
+        super(iNode, category);
+        if (category == EComponentCategory.BASIC) {
+            addSchemaProperty();
+        }
+    }
+
+    /**
+     * FIXME
+     */
+    private void addSchemaProperty() {
+        ElementParameter schema = new TaCoKitElementParameter(getNode());
+        schema.setName("SCHEMA");
+        schema.setDisplayName("!!!SCHEMA.NAME!!!");
+        schema.setCategory(EComponentCategory.BASIC);
+        schema.setFieldType(EParameterFieldType.SCHEMA_TYPE);
+        schema.setNumRow(1);
+        schema.setShow(true);
+        schema.setReadOnly(false);
+        schema.setRequired(true);
+        schema.setContext(EConnectionType.FLOW_MAIN.getName());
+
+        // add child parameters
+        // defines whether schema is built-in or repository
+        ElementParameter childParameter1 = new TaCoKitElementParameter(getNode());
+        childParameter1.setCategory(EComponentCategory.BASIC);
+        childParameter1.setContext(EConnectionType.FLOW_MAIN.getName());
+        childParameter1.setDisplayName("Schema");
+        childParameter1.setFieldType(EParameterFieldType.TECHNICAL);
+        childParameter1.setListItemsDisplayCodeName(new String[] { "BUILT_IN", "REPOSITORY" });
+        childParameter1.setListItemsDisplayName(new String[] { "Built-In", "Repository" });
+        childParameter1.setListItemsValue(new String[] { "BUILT_IN", "REPOSITORY" });
+        childParameter1.setName(EParameterName.SCHEMA_TYPE.getName());
+        childParameter1.setNumRow(1);
+        childParameter1.setParentParameter(schema);
+        childParameter1.setShow(true);
+        childParameter1.setShowIf("SCHEMA =='REPOSITORY'");
+        childParameter1.setValue("BUILT_IN");
+        schema.getChildParameters().put(EParameterName.SCHEMA_TYPE.getName(), childParameter1);
+
+        ElementParameter childParameter2 = new TaCoKitElementParameter(getNode());
+        childParameter2.setCategory(EComponentCategory.BASIC);
+        childParameter2.setContext(EConnectionType.FLOW_MAIN.getName());
+        childParameter2.setDisplayName("Repository");
+        childParameter2.setFieldType(EParameterFieldType.TECHNICAL);
+        childParameter2.setListItemsDisplayName(new String[0]);
+        childParameter2.setListItemsValue(new String[0]);
+        childParameter2.setName(EParameterName.REPOSITORY_SCHEMA_TYPE.getName());
+        childParameter2.setParentParameter(schema);
+        childParameter2.setRequired(true);
+        childParameter2.setShow(false);
+        childParameter2.setValue("");
+        schema.getChildParameters().put(EParameterName.REPOSITORY_SCHEMA_TYPE.getName(), childParameter2);
+
+        addSetting(schema);
+    }
+}

--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
@@ -39,7 +39,7 @@ public class SettingsCreator implements PropertyVisitor {
      * If numRow = 10, this does not necessarily mean that widget will be shown on 10th line,
      * but when 1 parameter has numRow = 8, and 2 has numRow = 10, then 2 will shown under 1
      */
-    private int lastRowNumber = 1;
+    private int lastRowNumber = 2;
 
     /**
      * Element(Node) for which parameters are created. It is required to set {@link ElementParameter} constructor
@@ -96,6 +96,14 @@ public class SettingsCreator implements PropertyVisitor {
             }
             settings.add(parameter);
         }
+    }
+
+    IElement getNode() {
+        return this.iNode;
+    }
+
+    void addSetting(final ElementParameter setting) {
+        settings.add(setting);
     }
 
     /**


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?

adds Schema by default for every component on Basic view.
Side effect: it adds schema also to Dataset and Datastore (it can be fixed)
