### PR TITLE
Igonchar/tcomp 681 enum in table

### DIFF
--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/TaCoKitElementParameter.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/metadata/TaCoKitElementParameter.java
@@ -74,6 +74,24 @@ public class TaCoKitElementParameter extends ElementParameter {
         }
     }
 
+    /**
+     * Computes index of specified <code>item</code> either in itemsDisplayCodeName or itemsDisplayCodeName
+     * super class fields
+     * This overridden implementation fixes an error, when <code>item</code> wasn't found in both arrays.
+     * It returns 0 in such case instead of -1. -1 causes ArrayIndexOutOfBoundsException, when new table column is added
+     * 
+     * @param item default closed list value
+     * @return default value index in possible values array
+     */
+    @Override
+    public int getIndexOfItemFromList(final String item) {
+        int index = super.getIndexOfItemFromList(item);
+        if (index == -1) {
+            return 0;
+        }
+        return index;
+    }
+
     public interface IValueChangedListener {
 
         void onValueChanged(final TaCoKitElementParameter elementParameter, final Object oldValue,

--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/model/parameter/SettingsCreator.java
@@ -142,6 +142,8 @@ public class SettingsCreator implements PropertyVisitor {
         parameter.setListItemsNotReadOnlyIf(new String[possibleValues.size()]);
         parameter.setListItemsShowIf(new String[possibleValues.size()]);
         parameter.setListItemsNotShowIf(new String[possibleValues.size()]);
+        parameter.setDefaultClosedListValue(node.getProperty().getDefaultValue());
+        parameter.setDefaultValue(node.getProperty().getDefaultValue());
         return parameter;
     }
 


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?

fixes ArrayIndexOutOfBoundException when enum column is used in Table property.
The problem occurred, when enum column property has no default value.
Table row stores enum value as an index of the chosen value in possible values array.
Thus, it tries to find an index. When default value is missed, ElementParameter returns -1. 
It causes Exception.
