### PR TITLE
feat(TCOMP-683): Guess schema

### DIFF
--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/ServerManager.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/ServerManager.java
@@ -17,6 +17,7 @@ package org.talend.sdk.component.studio;
 
 import static org.talend.sdk.component.studio.GAV.GROUP_ID;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Hashtable;
@@ -54,11 +55,7 @@ public class ServerManager extends AbstractUIPlugin {
             return;
         }
 
-        TemplatesExtractor extractor = new TemplatesExtractor("jet_stub/generic",
-                Platform
-                        .asLocalURL(Platform.getPlugin("org.talend.designer.codegen").getDescriptor().getInstallURL())
-                        .getFile());
-        extractor.extract();
+        extractFiles();
 
         reset = Lookups.init();
 
@@ -73,6 +70,21 @@ public class ServerManager extends AbstractUIPlugin {
         services.add(ctx.registerService(WebSocketClient.class.getName(), client, new Hashtable<>()));
         services.add(ctx.registerService(ComponentService.class.getName(), new ComponentService(), new Hashtable<>()));
         services.add(ctx.registerService(TaCoKitCache.class.getName(), new TaCoKitCache(), new Hashtable<>()));
+    }
+
+    private void extractFiles() throws IOException {
+        TemplatesExtractor stubExtractor = new TemplatesExtractor("jet_stub/generic",
+                Platform
+                        .asLocalURL(Platform.getPlugin("org.talend.designer.codegen").getDescriptor().getInstallURL())
+                        .getFile(),
+                "tacokit/jet_stub");
+        stubExtractor.extract();
+        TemplatesExtractor guessSchemaExtractor = new TemplatesExtractor("components/tTaCoKitGuessSchema",
+                Platform
+                        .asLocalURL(Platform.getPlugin("org.talend.designer.codegen").getDescriptor().getInstallURL())
+                        .getFile(),
+                "tacokit/components");
+        guessSchemaExtractor.extract();
     }
 
     @Override

--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/TemplatesExtractor.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/TemplatesExtractor.java
@@ -33,10 +33,12 @@ public class TemplatesExtractor {
 
     private final String destinationFolder;
 
+    private final String destinationSuffix;
+
     public void extract() throws IOException {
         final Bundle bundle = FrameworkUtil.getBundle(this.getClass());
         final URL templateEntry = bundle.getEntry(templatesPath);
-        final File destDir = new File(destinationFolder, "tacokit/jet_stub");
+        final File destDir = new File(destinationFolder, destinationSuffix);
         final String templateFolderPath = FileLocator.toFileURL(templateEntry).getPath();
         final File templateFolder = new File(templateFolderPath);
         org.talend.utils.io.FilesUtils.copyDirectory(templateFolder, destDir);

--- a/component-studio-integration/src/main/java/org/talend/sdk/component/studio/provider/TaCoKitComponentsProvider.java
+++ b/component-studio-integration/src/main/java/org/talend/sdk/component/studio/provider/TaCoKitComponentsProvider.java
@@ -13,6 +13,7 @@
 package org.talend.sdk.component.studio.provider;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
@@ -20,7 +21,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.talend.commons.exception.ExceptionHandler;
 import org.talend.core.model.components.AbstractComponentsProvider;
-import org.talend.sdk.component.studio.util.TaCoKitConst;
+// import org.talend.sdk.component.studio.util.TaCoKitConst;
 
 public class TaCoKitComponentsProvider extends AbstractComponentsProvider {
 
@@ -30,13 +31,12 @@ public class TaCoKitComponentsProvider extends AbstractComponentsProvider {
 
     @Override
     protected File getExternalComponentsLocation() {
-
-        URL url = FileLocator.find(Platform.getBundle(TaCoKitConst.BUNDLE_ID), new Path(getFolderName()), null);
+        URL url = FileLocator.find(Platform.getBundle("org.talend.designer.codegen"), new Path(getFolderName()), null);
         URL fileUrl;
         try {
             fileUrl = FileLocator.toFileURL(url);
             return new File(fileUrl.getPath());
-        } catch (Exception e) {
+        } catch (IOException e) {
             ExceptionHandler.process(e);
         }
         return null;
@@ -44,7 +44,19 @@ public class TaCoKitComponentsProvider extends AbstractComponentsProvider {
 
     @Override
     public String getFolderName() {
-        return "components"; //$NON-NLS-1$
+        return "tacokit/components"; //$NON-NLS-1$
+    }
+
+    public boolean isCustom() {
+        return true;
+    }
+
+    public String getComponentsBundle() {
+        return "org.talend.designer.codegen";
+    }
+
+    public String getComponentsLocation() {
+        return getFolderName();
     }
 
 }


### PR DESCRIPTION
* Extract guess schema javajets

* Implement methods required for guess schema in studio

Should work after https://github.com/Talend/tdi-studio-se/pull/1854 and https://github.com/Talend/tcommon-studio-se/pull/1369 are merged
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
