### PR TITLE
feat(TCOMP-681): enrich ConfigurationType with ActionReference

### DIFF
--- a/component-server/src/main/java/org/talend/sdk/component/server/front/filter/message/MessageResponseFilter.java
+++ b/component-server/src/main/java/org/talend/sdk/component/server/front/filter/message/MessageResponseFilter.java
@@ -28,10 +28,11 @@ public class MessageResponseFilter implements DynamicFeature {
 
     @Override
     public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
-        if (resourceInfo.getResourceMethod().isAnnotationPresent(DeprecatedEndpoint.class) ||
-                resourceInfo.getResourceClass().isAnnotationPresent(DeprecatedEndpoint.class)) {
-            context.register((ContainerResponseFilter) (requestContext, responseContext) -> responseContext.getHeaders()
-                    .putSingle("X-Talend-Warning", "This endpoint is deprecated and will be removed without notice soon."));
+        if (resourceInfo.getResourceMethod().isAnnotationPresent(DeprecatedEndpoint.class)
+                || resourceInfo.getResourceClass().isAnnotationPresent(DeprecatedEndpoint.class)) {
+            context.register((ContainerResponseFilter) (requestContext,
+                    responseContext) -> responseContext.getHeaders().putSingle("X-Talend-Warning",
+                            "This endpoint is deprecated and will be removed without notice soon."));
         }
     }
 }

--- a/component-server/src/main/java/org/talend/sdk/component/server/front/model/ConfigTypeNode.java
+++ b/component-server/src/main/java/org/talend/sdk/component/server/front/model/ConfigTypeNode.java
@@ -16,6 +16,7 @@
 package org.talend.sdk.component.server.front.model;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,4 +43,7 @@ public class ConfigTypeNode {
     private Set<String> edges = new HashSet<>();
 
     private List<SimplePropertyDefinition> properties = new ArrayList<>();
+
+    private Collection<ActionReference> actions;
+
 }

--- a/component-server/src/main/java/org/talend/sdk/component/server/service/ActionsService.java
+++ b/component-server/src/main/java/org/talend/sdk/component/server/service/ActionsService.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.talend.sdk.component.server.service;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.talend.sdk.component.container.Container;
+import org.talend.sdk.component.design.extension.repository.Config;
+import org.talend.sdk.component.runtime.manager.ComponentFamilyMeta;
+import org.talend.sdk.component.runtime.manager.ContainerComponentRegistry;
+import org.talend.sdk.component.runtime.manager.ParameterMeta;
+import org.talend.sdk.component.runtime.manager.reflect.parameterenricher.ActionParameterEnricher;
+import org.talend.sdk.component.server.front.model.ActionReference;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ApplicationScoped
+public class ActionsService {
+
+    @Inject
+    private PropertiesService propertiesService;
+
+    public Collection<ActionReference> findActions(final String family, final Container container, final Locale locale,
+            final ComponentFamilyMeta.BaseMeta<Object> meta) {
+        final Set<ActionReference> actions = getActionReference(meta);
+        return findActions(family, actions, container, locale);
+    }
+
+    public Collection<ActionReference> findActions(final String family, final Container container, final Locale locale,
+            final Config config) {
+        final Set<ActionReference> actions =
+                getActionReference(toStream(Collections.singleton(config.getMeta())), family);
+        return findActions(family, actions, container, locale);
+    }
+
+    public Set<ActionReference> getActionReference(final ComponentFamilyMeta.BaseMeta<Object> meta) {
+        return getActionReference(toStream(meta.getParameterMetas()), meta.getParent().getName());
+    }
+
+    public Set<ActionReference> getActionReference(final Stream<ParameterMeta> parameters, final String familyName) {
+        return parameters
+                .flatMap(p -> p.getMetadata().entrySet().stream())
+                .filter(e -> e.getKey().startsWith(ActionParameterEnricher.META_PREFIX))
+                .map(e -> new ActionReference(familyName, e.getValue(),
+                        e.getKey().substring(ActionParameterEnricher.META_PREFIX.length()), null))
+                .collect(toSet());
+    }
+
+    private Collection<ActionReference> findActions(final String family, final Set<ActionReference> actions,
+            final Container container, final Locale locale) {
+        final ContainerComponentRegistry registry = container.get(ContainerComponentRegistry.class);
+        return registry
+                .getServices()
+                .stream()
+                .flatMap(s -> s.getActions().stream())
+                .filter(s -> s.getFamily().equals(family))
+                .filter(s -> actions
+                        .stream()
+                        .anyMatch(e -> s.getFamily().equals(e.getFamily()) && s.getType().equals(e.getType())
+                                && s.getAction().equals(e.getName())))
+                .map(s -> new ActionReference(s.getFamily(), s.getAction(), s.getType(),
+                        propertiesService
+                                .buildProperties(s.getParameters(), container.getLoader(), locale, null)
+                                .collect(toList())))
+                .collect(toList());
+    }
+
+    private Stream<ParameterMeta> toStream(final Collection<ParameterMeta> parameterMetas) {
+        return Stream.concat(parameterMetas.stream(),
+                parameterMetas.stream().map(ParameterMeta::getNestedParameters).filter(Objects::nonNull).flatMap(
+                        this::toStream));
+    }
+}


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?

Enriches ConfigTypeNode with ActionReferences
Implements ActionsService to be used by both ComponentResource and ConfigurationTypeResource
