### PR TITLE
feat(TFD-5795): Add a quick sample limit to PartitionMapper in Beam.

### DIFF
--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
@@ -577,7 +577,7 @@ public class ComponentManager implements AutoCloseable {
                                             "org.apache.beam.repackaged.", "org.apache.beam.vendor.",
                                             "org.talend.sdk.component.runtime.beam.", "org.codehaus.jackson.",
                                             "com.fasterxml.jackson.annotation.", "com.fasterxml.jackson.core.",
-                                            "com.fasterxml.jackson.databind.", "com.thoughtwors.paranamer.",
+                                            "com.fasterxml.jackson.databind.", "com.thoughtworks.paranamer.",
                                             "org.apache.commons.compress.", "org.tukaani.xz.", "org.objenesis.",
                                             "org.joda.time.", "org.xerial.snappy.", "avro.shaded.", "org.apache.avro.",
                                             // scala - most engines


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

Provide quick sampling on PartitionMapper created through tacokit in the Beam transformation.

### What does this PR adds (design/code thoughts)?

1. Limiting the number of sources/partitions to 1 when sampling is used, just sequentially asking the component for the next record.
2. "Countdown" for remaining records means that the limit is "per-source" (unlike Beam's BoundedSourceFromUnboundedSource, which reshuffles results).
3. Infinite mappers are turned into finite mappers when this stopping constraint is added.