### PR TITLE
fix(TFD-6207): Relax beam core artifact identification by filename.

### DIFF
--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
@@ -885,7 +885,7 @@ public class ComponentManager implements AutoCloseable {
                         try {
                             return new File(decode(new URL(file.substring(0, separator)).getFile()))
                                     .getName()
-                                    .startsWith("beam-sdks-java-core-");
+                                    .contains("beam-sdks-java-core-");
 
                         } catch (final MalformedURLException e) {
                             // let it return false

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
@@ -883,9 +883,10 @@ public class ComponentManager implements AutoCloseable {
                     final int separator = file.indexOf('!');
                     if (separator > 0) {
                         try {
-                            return new File(decode(new URL(file.substring(0, separator)).getFile()))
-                                    .getName()
-                                    .contains("beam-sdks-java-core-");
+                            String strippedJar =
+                                    new File(decode(new URL(file.substring(0, separator)).getFile())).getName();
+                            return strippedJar.startsWith("beam-sdks-java-core-")
+                                    || strippedJar.startsWith("org.apache.beam.beam-sdks-java-core-");
 
                         } catch (final MalformedURLException e) {
                             // let it return false


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

`beam-sdks-java-core` classes are identified and loaded from the parent classloader by looking at the code location, and matching against the filename of the jar.

Some of our services use the sbt-native-packager which copies artifacts to a `lib/` directory and *renames* them by prefixing the group id, which doesn't work with the current logic.

### What does this PR adds (design/code thoughts)?

Relax how the beam core jar is identified by looking at the jar file name with and without the prefixed group id.