### PR TITLE
chore : add an option to disable AllowedIPs check

### DIFF
--- a/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
+++ b/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
@@ -58,9 +58,9 @@ public class SecurityFilter implements Filter {
     private Boolean docker;
     
     @Inject
-    @Documentation("Disable IP/host white list")
-    @ConfigProperty(name = "talend.vault.cache.security.allowedIps.disable", defaultValue = "false")
-    private Boolean disableAllowedIps;
+    @Documentation("Enable Allowed IP list")
+    @ConfigProperty(name = "talend.vault.cache.security.allowedIps.enable", defaultValue = "true")
+    private Boolean enableAllowedIPsCheck;
 
     @Inject
     private DockerHostNameSanitizer dockerSanitizer;
@@ -90,11 +90,11 @@ public class SecurityFilter implements Filter {
 
     // cheap security
     private boolean isAllowed(final HttpServletRequest request) {
-        if(!disableAllowedIps) {
+        if(enableAllowedIPsCheck) {
+            return allowedIp.contains(request.getRemoteAddr()) || allowedIp.contains(sanitizeHost(request.getRemoteHost()));
+        } else {
             log.debug("Allowed IPs checking is disabled, request will be accepted");
             return true
-        } else {
-            return allowedIp.contains(request.getRemoteAddr()) || allowedIp.contains(sanitizeHost(request.getRemoteHost()));
         }
     }
 

--- a/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
+++ b/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
@@ -54,7 +54,7 @@ public class SecurityFilter implements Filter {
 
     @Inject
     @Documentation("Enable to sanitize the hostname before testing them.")
-    @ConfigProperty(name = "talend.vault.cache.security.disable.docker", defaultValue = "false")
+    @ConfigProperty(name = "talend.vault.cache.security.hostname.docker", defaultValue = "false")
     private Boolean docker;
     
     @Inject

--- a/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
+++ b/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/security/SecurityFilter.java
@@ -54,8 +54,13 @@ public class SecurityFilter implements Filter {
 
     @Inject
     @Documentation("Enable to sanitize the hostname before testing them.")
-    @ConfigProperty(name = "talend.vault.cache.security.hostname.docker", defaultValue = "false")
+    @ConfigProperty(name = "talend.vault.cache.security.disable.docker", defaultValue = "false")
     private Boolean docker;
+    
+    @Inject
+    @Documentation("Disable IP/host white list")
+    @ConfigProperty(name = "talend.vault.cache.security.allowedIps.disable", defaultValue = "false")
+    private Boolean disableAllowedIps;
 
     @Inject
     private DockerHostNameSanitizer dockerSanitizer;
@@ -85,7 +90,12 @@ public class SecurityFilter implements Filter {
 
     // cheap security
     private boolean isAllowed(final HttpServletRequest request) {
-        return allowedIp.contains(request.getRemoteAddr()) || allowedIp.contains(sanitizeHost(request.getRemoteHost()));
+        if(!disableAllowedIps) {
+            log.debug("Allowed IPs checking is disabled, request will be accepted");
+            return true
+        } else {
+            return allowedIp.contains(request.getRemoteAddr()) || allowedIp.contains(sanitizeHost(request.getRemoteHost()));
+        }
     }
 
     private String sanitizeHost(final String remoteHost) {


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
There's an inconsistent behavior when the proxy is deployed in a docker stack with a user defined netwrok (weave, ...). This PR allows the user to disable completely the AllowedIPs check. 

### What does this PR adds (design/code thoughts)?
A new option with a default False value to disable the AllowedIPs check