### PR TITLE
[TCOMP-1341] Add DeployInStudioTask in Gradle Plugin

### DIFF
--- a/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
+++ b/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
@@ -82,9 +82,9 @@ public class TaCoKitPlugin implements Plugin<Project> {
         project.task(new HashMap<String, Object>() {
 
             {
-                put("type", DependenciesTask.class);
-                put("group", group);
-                put("description",
+                put(Task.TASK_TYPE, DependenciesTask.class);
+                put(Task.TASK_GROUP, group);
+                put(Task.TASK_DESCRIPTION,
                         "Creates the Talend Component Kit dependencies file used by the runtime to build the component classloader");
             }
         }, "talendComponentKitDependencies");
@@ -100,9 +100,10 @@ public class TaCoKitPlugin implements Plugin<Project> {
         project.task(new HashMap<String, Object>() {
 
             {
-                put("type", ValidateTask.class);
-                put("group", group);
-                put("description", "Validates that the module components are respecting the component standards.");
+                put(Task.TASK_TYPE, ValidateTask.class);
+                put(Task.TASK_GROUP, group);
+                put(Task.TASK_DESCRIPTION,
+                        "Validates that the module components are respecting the component standards.");
             }
         }, "talendComponentKitValidation");
         project
@@ -117,9 +118,9 @@ public class TaCoKitPlugin implements Plugin<Project> {
         project.task(new HashMap<String, Object>() {
 
             {
-                put("type", DocumentationTask.class);
-                put("group", group);
-                put("description", "Generates an asciidoc file with the documentation of the components.");
+                put(Task.TASK_TYPE, DocumentationTask.class);
+                put(Task.TASK_GROUP, group);
+                put(Task.TASK_DESCRIPTION, "Generates an asciidoc file with the documentation of the components.");
             }
         }, "talendComponentKitDocumentation");
         project
@@ -134,9 +135,9 @@ public class TaCoKitPlugin implements Plugin<Project> {
         project.task(new HashMap<String, Object>() {
 
             {
-                put("type", WebTask.class);
-                put("group", group);
-                put("description",
+                put(Task.TASK_TYPE, WebTask.class);
+                put(Task.TASK_GROUP, group);
+                put(Task.TASK_DESCRIPTION,
                         "Starts a web server allowing you to browse your components (requires the component to be installed before).");
             }
         }, "talendComponentKitWebServer");
@@ -145,9 +146,9 @@ public class TaCoKitPlugin implements Plugin<Project> {
         project.task(new HashMap<String, Object>() {
 
             {
-                put("type", CarTask.class);
-                put("group", group);
-                put("description", "Creates a Component ARchive (.car) based on current project.");
+                put(Task.TASK_TYPE, CarTask.class);
+                put(Task.TASK_GROUP, group);
+                put(Task.TASK_DESCRIPTION, "Creates a Component ARchive (.car) based on current project.");
             }
         }, "talendComponentKitComponentArchive");
 

--- a/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
+++ b/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -149,5 +150,16 @@ public class TaCoKitPlugin implements Plugin<Project> {
                 put("description", "Creates a Component ARchive (.car) based on current project.");
             }
         }, "talendComponentKitComponentArchive");
+
+        // deploy in studio
+        project.task(new HashMap<String, Object>() {
+
+            {
+                put(Task.TASK_TYPE, DeployInStudioTask.class);
+                put(Task.TASK_GROUP, "Talend Component Kit deployment");
+                put(Task.TASK_DESCRIPTION, "Deploys the module components to the Studio.");
+                put(Task.TASK_DEPENDS_ON, "jar");
+            }
+        }, "deployInStudio");
     }
 }

--- a/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
+++ b/gradle-talend-component/src/main/java/org/talend/sdk/component/gradle/TaCoKitPlugin.java
@@ -157,10 +157,10 @@ public class TaCoKitPlugin implements Plugin<Project> {
 
             {
                 put(Task.TASK_TYPE, DeployInStudioTask.class);
-                put(Task.TASK_GROUP, "Talend Component Kit deployment");
+                put(Task.TASK_GROUP, group);
                 put(Task.TASK_DESCRIPTION, "Deploys the module components to the Studio.");
                 put(Task.TASK_DEPENDS_ON, "jar");
             }
-        }, "deployInStudio");
+        }, "talendComponentKitDeployInStudio");
     }
 }


### PR DESCRIPTION
## Requirements

## Why this PR is needed?
- Currently the Talend Gradle Component plugin lacks of the possibility to deploy the module components to the Studio.

## What does this PR adds (design/code thoughts)?
- The task was already existed in the plugin, but was not registered. I just added this task so users can deploy from CLI.