### PR TITLE
fix(TFD-7165): Use LogicalTypes.timestampMillis() on DATETIME.

### DIFF
--- a/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaBuilder.java
+++ b/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaBuilder.java
@@ -23,6 +23,7 @@ import static org.talend.sdk.component.runtime.record.Schemas.EMPTY_RECORD;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.avro.LogicalTypes;
 import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.runtime.beam.avro.AvroSchemas;
 import org.talend.sdk.component.runtime.manager.service.api.Unwrappable;
@@ -42,7 +43,12 @@ public class AvroSchemaBuilder implements Schema.Builder {
             new AvroSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
 
     private static final AvroSchema DATETIME_SCHEMA = new AvroSchema(new AvroPropertyMapper() {
-    }.setProp(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG), Schema.Type.DATETIME.name(), "true"));
+    }
+            .setProp(
+                    LogicalTypes
+                            .timestampMillis()
+                            .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG)),
+                    Schema.Type.DATETIME.name(), "true"));
 
     private static final AvroSchema STRING_SCHEMA =
             new AvroSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
@@ -68,7 +74,10 @@ public class AvroSchemaBuilder implements Schema.Builder {
     private static final AvroSchema DATETIME_SCHEMA_NULLABLE =
             new AvroSchema(org.apache.avro.Schema.createUnion(asList(NULL_SCHEMA, new AvroPropertyMapper() {
             }
-                    .setProp(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG),
+                    .setProp(
+                            LogicalTypes
+                                    .timestampMillis()
+                                    .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG)),
                             Schema.Type.DATETIME.name(), "true"))));
 
     private static final AvroSchema STRING_SCHEMA_NULLABLE = new AvroSchema(org.apache.avro.Schema

--- a/component-runtime-beam/src/test/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaTest.java
+++ b/component-runtime-beam/src/test/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaTest.java
@@ -26,6 +26,7 @@ import static org.talend.sdk.component.api.record.Schema.Type.STRING;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.junit.jupiter.api.Test;
 import org.talend.sdk.component.api.service.record.RecordBuilderFactory;
@@ -76,6 +77,7 @@ class AvroSchemaTest {
                         .build())
                 .getDelegate();
         assertEquals(DATETIME, new AvroSchema(avro).getEntries().iterator().next().getType());
+        assertEquals(LogicalTypes.timestampMillis(), LogicalTypes.fromSchema(avro.getField("date").schema()));
     }
 
     @Test


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

When building Avro, the tacokit DATETIME is indistinguishable from a LONG.

### What does this PR adds (design/code thoughts)?

Annotate the Avro schema with standard LogicalTypes.timestampMillis().
