### PR TITLE
Fix wrong condition

### DIFF
--- a/component-tools/src/main/java/org/talend/sdk/component/tools/exec/CarMain.java
+++ b/component-tools/src/main/java/org/talend/sdk/component/tools/exec/CarMain.java
@@ -141,7 +141,7 @@ public class CarMain {
 
     private static void deployInM2(final String m2) {
         final File m2File = new File(m2);
-        if (m2File.exists()) {
+        if (!m2File.exists()) {
             throw new IllegalArgumentException(m2 + " doesn't exist");
         }
         final String component = installJars(m2File);


### PR DESCRIPTION
## Requirements

## Why this PR is needed?
- Following the docs at https://talend.github.io/component-runtime/main/1.1.8/build-tools-maven.html#_generating_the_component_archive I found an issue when trying to install the component to a local maven repo by
```
# for a m2 provisioning
java -jar mycomponent.car maven-deploy /path/to/.m2/repository
```

## What does this PR adds (design/code thoughts)?
- Fix the wrong condition in CarMain.