### PR TITLE
fix(TFD-7292): Correctly interpret Avro LogicalType as tacokit type.

### DIFF
--- a/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchema.java
+++ b/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchema.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import javax.json.bind.annotation.JsonbTransient;
 
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.talend.sdk.component.runtime.manager.service.api.Unwrappable;
 import org.talend.sdk.component.runtime.record.SchemaImpl;
@@ -125,7 +126,8 @@ public class AvroSchema implements org.talend.sdk.component.api.record.Schema, A
     private Type doMapType(final Schema schema) {
         switch (schema.getType()) {
         case LONG:
-            if (Boolean.parseBoolean(readProp(schema, Type.DATETIME.name()))) {
+            if (Boolean.parseBoolean(readProp(schema, Type.DATETIME.name()))
+                    || LogicalTypes.timestampMillis().equals(LogicalTypes.fromSchemaIgnoreInvalid(schema))) {
                 return Type.DATETIME;
             }
             return Type.LONG;

--- a/component-runtime-beam/src/test/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaTest.java
+++ b/component-runtime-beam/src/test/java/org/talend/sdk/component/runtime/beam/spi/record/AvroSchemaTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.junit.jupiter.api.Test;
 import org.talend.sdk.component.api.service.record.RecordBuilderFactory;
 import org.talend.sdk.component.runtime.beam.spi.AvroRecordBuilderFactoryProvider;
@@ -78,6 +79,18 @@ class AvroSchemaTest {
                 .getDelegate();
         assertEquals(DATETIME, new AvroSchema(avro).getEntries().iterator().next().getType());
         assertEquals(LogicalTypes.timestampMillis(), LogicalTypes.fromSchema(avro.getField("date").schema()));
+    }
+
+    @Test
+    void checkDateConversionFromExternalAvro() {
+        final org.apache.avro.Schema avro = SchemaBuilder
+                .record("test")
+                .fields()
+                .name("date")
+                .type(LogicalTypes.timestampMillis().addToSchema(Schema.create(Schema.Type.LONG)))
+                .noDefault()
+                .endRecord();
+        assertEquals(DATETIME, new AvroSchema(avro).getEntries().iterator().next().getType());
     }
 
     @Test


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

Follow-up to TFD-7165 / #361

The current assumption is that all Avro records are tagged with tacokit properties to determine the official tacokit type.  In some cases (such as reading directly from Avro, or using an intermediate processor that doesn't annotate or propagate tacokit types), this information is not available.

Normally the mapping is OK and transparent anyway, except for DateTime, which should fall back to the LogicalType provided by Avro.

### What does this PR adds (design/code thoughts)?

Date, Time are not supported, just DateTime --> LogicalTypes.timestampMillis()