### PR TITLE
fix(TCOMP-1441): init Parameter in the UISchema builder

### DIFF
--- a/component-form/component-form-model/src/main/java/org/talend/sdk/component/form/model/uischema/UiSchema.java
+++ b/component-form/component-form-model/src/main/java/org/talend/sdk/component/form/model/uischema/UiSchema.java
@@ -312,7 +312,8 @@ public class UiSchema {
                 if (this.parameters == null) {
                     this.parameters = new ArrayList<>();
                 }
-                this.parameters.add(new Parameter());
+                final Parameter parameter = parameter().withKey(key).withPath(path).build();
+                this.parameters.add(parameter);
                 return this;
             }
 


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

fix https://jira.talendforge.org/browse/TCOMP-1441

### What does this PR adds (design/code thoughts)?

initialize the new instance of UISchema Parameter class with a key and a path before adding it to the list of parameters of the schema.
