### PR TITLE
TCOMP-1554 - Fix for potential "Zip Slip" vulnerabilites

### DIFF
--- a/component-starter-server/src/main/java/org/talend/sdk/component/starter/server/front/ProjectResource.java
+++ b/component-starter-server/src/main/java/org/talend/sdk/component/starter/server/front/ProjectResource.java
@@ -309,6 +309,9 @@ public class ProjectResource {
                                 .substring(ofNullable(project.getModel().getArtifact()).orElse("application").length()
                                         + 1);
                         final File out = new File(workDir, path);
+                        if (!out.getCanonicalPath().startsWith(workDir.getCanonicalPath())) {
+                            throw new IOException("The output file is not contained in the destination directory");
+                        }
                         out.getParentFile().mkdirs();
 
                         // we need to filter some files, we can filter more files later but for now it is not

--- a/component-tools/src/main/java/org/talend/sdk/component/tools/exec/CarMain.java
+++ b/component-tools/src/main/java/org/talend/sdk/component/tools/exec/CarMain.java
@@ -281,6 +281,9 @@ public class CarMain {
                 if (entry.getName().startsWith("MAVEN-INF/repository/")) {
                     final String path = entry.getName().substring("MAVEN-INF/repository/".length());
                     final File output = new File(m2Root, path);
+                    if (!output.getCanonicalPath().startsWith(m2Root.getCanonicalPath())) {
+                        throw new IOException("The output file is not contained in the destination directory");
+                    }
                     if (output.exists()) {
                         System.out.println(output + " already exists, skipping");
                     } else {

--- a/talend-component-kit-intellij-plugin/src/main/java/org/talend/sdk/component/intellij/module/ProjectDownloader.java
+++ b/talend-component-kit-intellij-plugin/src/main/java/org/talend/sdk/component/intellij/module/ProjectDownloader.java
@@ -117,6 +117,9 @@ public class ProjectDownloader {
                     path = path.replaceFirst("^[^/]+/", "");
                 }
                 final File file = new File(destination, path);
+                if (!file.getCanonicalPath().startsWith(destination.getCanonicalPath())) {
+                    throw new IOException("The output file is not contained in the destination directory");
+                }
 
                 if (entry.isDirectory()) {
                     indicator.setText("Creating directory " + file.getName());


### PR DESCRIPTION
There are some potential "Zip Slip" vulnerabilities in tcompe, when a zip file containing "../.." type entries can break out of the destination path when being extracted:

./component-runtime/component-tools/src/main/java/org/talend/sdk/component/tools/exec/CarMain.java
./component-runtime/talend-component-kit-intellij-plugin/src/main/java/org/talend/sdk/component/intellij/module/ProjectDownloader.java
./component-runtime/component-starter-server/src/main/java/org/talend/sdk/component/starter/server/front/ProjectResource.java