### PR TITLE
Switch ClientSetup to use TLS instead of SSL

### DIFF
--- a/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/service/http/ClientSetup.java
+++ b/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/service/http/ClientSetup.java
@@ -321,7 +321,7 @@ public class ClientSetup {
             }
         } };
         try {
-            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, trustManagers, new java.security.SecureRandom());
             return sslContext;
         } catch (final NoSuchAlgorithmException | KeyManagementException e) {


### PR DESCRIPTION
Even for createUnsafeSSLContext I don't see any reason to use SSL in SSLContext.getInstance.