### PR TITLE
Add configuration to allow directly a subnet on vault-proxy

### DIFF
--- a/component-server-parent/component-server-vault-proxy/pom.xml
+++ b/component-server-parent/component-server-vault-proxy/pom.xml
@@ -42,6 +42,11 @@
       <version>${commons-cli.version}</version>
     </dependency>
     <dependency>
+      <groupId>commons-net</groupId>
+      <artifactId>commons-net</artifactId>
+      <version>${commons-net.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.johnzon</groupId>
       <artifactId>johnzon-jsonb</artifactId>
       <version>${johnzon.version}</version>

--- a/documentation/src/main/antora/modules/ROOT/pages/_partials/generated_server-vault-proxy-configuration.adoc
+++ b/documentation/src/main/antora/modules/ROOT/pages/_partials/generated_server-vault-proxy-configuration.adoc
@@ -30,6 +30,7 @@ talend.vault.cache.jcache.manager.uri:: Default value: `geronimo://simple-jcache
 talend.vault.cache.jcache.maxCacheSize:: Default value: `100000`. JCache max size per cache.
 talend.vault.cache.jcache.refresh.period:: Default value: `30000`. How often (in ms) the Component Server should be checked to invalidate the caches on the component parameters (to identify credentials).
 talend.vault.cache.security.allowedIps:: Default value: `localhost,127.0.0.1,0:0:0:0:0:0:0:1`. The IP or hosts allowed to call that server on `/api/*` if no token is passed.
+talend.vault.cache.security.allowedSubnet:: The subnet allowed to call that server on `/api/*` if no token is passed.
 talend.vault.cache.security.hostname.sanitizer:: Default value: `none`. Enable to sanitize the hostname before testing them. Default to `none` which is a noop. Supported values are `docker` (for `<folder>_<service>_<number>.<folder>_<network>` pattern) and `weave` (for `<prefix>_dataset_<number>.<suffix>` pattern).
 talend.vault.cache.security.tokens:: Default value: `-`. The tokens enabling a client to call this server without being in `allowedIp` whitelist.
 talend.vault.cache.service.auth.cantDecipherStatusCode:: Default value: `422`. Status code sent when vault can't decipher some values.

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
     <commons-compress.version>1.19</commons-compress.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-cli.version>1.4</commons-cli.version>
+    <commons-net.version>3.6</commons-net.version>
     <commons-text.version>1.6</commons-text.version>
     <geronimo-jaxrs.version>1.1</geronimo-jaxrs.version>
     <asciidoctorj.version>2.1.0</asciidoctorj.version>


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
In the context of K8s (cluster dev), it's not easy to configure the security to allow the communication between the client app and vault-proxy. We don't want to add a header for any request to the tacokit-vault-proxy. 

### What does this PR adds (design/code thoughts)?
The solution is to add a new configuration to the vault-proxy to allow a subnet and keep the security without adding any code in the client app. 