### PR TITLE
TCOMP-1692 - Update CXF to 3.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <meecrowave.version>1.2.9</meecrowave.version>
     <owb.version>2.0.15</owb.version>
     <tomcat.version>9.0.31</tomcat.version>
-    <cxf.version>3.3.5</cxf.version>
+    <cxf.version>3.3.6</cxf.version>
     <log4j2.version>2.13.1</log4j2.version>
     <logback.version>1.2.3</logback.version>
     <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION

We should update Apache CXF to 3.3.6 due to CVE-2020-1954:

http://cxf.apache.org/security-advisories.data/CVE-2020-1954.txt.asc?version=1&modificationDate=1585730169000&api=v2
