### PR TITLE
TCOMP-1697 - Update BouncyCastle to 1.65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <spotless.version>1.23.0</spotless.version>
     <jib.version>1.4.0</jib.version>
     <jib-core.version>0.13.1</jib-core.version>
-    <bouncycastle.version>1.64</bouncycastle.version>
+    <bouncycastle.version>1.65</bouncycastle.version>
     <commons-io.version>2.6</commons-io.version>
 
     <jruby.version>9.2.11.0</jruby.version>


### PR DESCRIPTION
This task is to update BouncyCastle to 1.65. In some of the projects, we needed to ship a beta version of 1.65 due to a bug with Java 11 and TLS.