### PR TITLE
TCOMP-1703 - Update Log4j 2 to 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <owb.version>2.0.15</owb.version>
     <tomcat.version>9.0.31</tomcat.version>
     <cxf.version>3.3.6</cxf.version>
-    <log4j2.version>2.13.1</log4j2.version>
+    <log4j2.version>2.13.2</log4j2.version>
     <logback.version>1.2.3</logback.version>
     <log4j.version>1.2.17</log4j.version>
     <geronimo-jcdi.version>1.1</geronimo-jcdi.version>


### PR DESCRIPTION


This task is to update Log4j 2 to 2.13.2 due to the following CVE:

[CVE-2020-9488] Improper validation of certificate with host mismatch in Apache Log4j SMTP appender

https://seclists.org/oss-sec/2020/q2/72
