### PR TITLE
fix(TCOMP-1698): UiSpecService injects a wrong property

### DIFF
--- a/component-form/component-form-core/src/main/java/org/talend/sdk/component/form/internal/converter/impl/PropertiesConverter.java
+++ b/component-form/component-form-core/src/main/java/org/talend/sdk/component/form/internal/converter/impl/PropertiesConverter.java
@@ -77,9 +77,9 @@ public class PropertiesConverter implements PropertyConverter {
                                     .getMetadata()
                                     .keySet()
                                     .stream()
-                                    .anyMatch(k -> k.equals("action::suggestions")
+                                    .anyMatch(k -> k.equalsIgnoreCase("action::suggestions")
                                             || k.equalsIgnoreCase("action::dynamic_values"))) {
-                                defaults.putIfAbsent("$" + property.getPath() + "_name", value);
+                                defaults.putIfAbsent("$" + property.getName() + "_name", value);
                             }
                             defaults.put(property.getName(), value);
                         }

--- a/component-form/component-form-core/src/test/java/org/talend/sdk/component/form/internal/converter/impl/PropertiesConverterTest.java
+++ b/component-form/component-form-core/src/test/java/org/talend/sdk/component/form/internal/converter/impl/PropertiesConverterTest.java
@@ -39,14 +39,15 @@ class PropertiesConverterTest {
         final Map<String, Object> values = new HashMap<>();
         try (final Jsonb jsonb = JsonbBuilder.create()) {
             new PropertiesConverter(jsonb, values, emptyList())
-                    .convert(completedFuture(new PropertyContext<>(new SimplePropertyDefinition("foo.bar", "bar", "Bar",
-                            "STRING", "def", new PropertyValidation(), singletonMap("action::suggestions", "yes"), null,
-                            new LinkedHashMap<>()), null, new PropertyContext.Configuration())))
+                    .convert(completedFuture(new PropertyContext<>(new SimplePropertyDefinition("configuration.foo.bar",
+                            "bar", "Bar", "STRING", "def", new PropertyValidation(),
+                            singletonMap("action::suggestionS", "yes"), null, new LinkedHashMap<>()), null,
+                            new PropertyContext.Configuration())))
                     .toCompletableFuture()
                     .get();
         }
         assertEquals(2, values.size());
         assertEquals("def", values.get("bar"));
-        assertEquals("def", values.get("$foo.bar_name"));
+        assertEquals("def", values.get("$bar_name"));
     }
 }


### PR DESCRIPTION
UiSpecService injects a wrong property for suggestions and dynamic_values
See: https://jira.talendforge.org/browse/TCOMP-1698

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
