### PR TITLE
fix(TCOMP-1719) : Header responses for icon not propagated correctly …

### DIFF
--- a/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/proxy/ComponentResourceProxy.java
+++ b/component-server-parent/component-server-vault-proxy/src/main/java/org/talend/sdk/component/runtime/server/vault/proxy/endpoint/proxy/ComponentResourceProxy.java
@@ -19,6 +19,7 @@ import static javax.ws.rs.client.Entity.entity;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.MediaType.APPLICATION_SVG_XML;
 import static org.talend.sdk.component.runtime.server.vault.proxy.endpoint.jaxrs.Responses.decorate;
 
 import java.util.Map;
@@ -104,14 +105,14 @@ public class ComponentResourceProxy {
     @GET
     @Path("icon/family/{id}")
     @CacheResult
-    @Produces({ APPLICATION_JSON, APPLICATION_OCTET_STREAM })
+    @Produces({ APPLICATION_JSON, APPLICATION_OCTET_STREAM, APPLICATION_SVG_XML })
     public CompletionStage<Response> familyIcon() {
         return handler.forward();
     }
 
     @GET
     @Path("icon/{id}")
-    @Produces({ APPLICATION_JSON, APPLICATION_OCTET_STREAM })
+    @Produces({ APPLICATION_JSON, APPLICATION_OCTET_STREAM, APPLICATION_SVG_XML })
     @CacheResult
     public CompletionStage<Response> icon() {
         return handler.forward();


### PR DESCRIPTION
…from Component-server-vault-proxy

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
Icons are returned from the component-server-vault-proxy with a Content-type: application/octet-stream even if the component-server returns an SVG icon with right header.

### What does this PR adds (design/code thoughts)?
