### PR TITLE
fix(TCOMP-1722): respect user's url input

### DIFF
--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/service/http/RequestParser.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/service/http/RequestParser.java
@@ -146,13 +146,7 @@ public class RequestParser {
                 if (urlProvider != null) {
                     throw new IllegalStateException(method + "has two Url parameters");
                 }
-                urlProvider = params -> {
-                    String url = String.valueOf(params[index]);
-                    if (url != null && url.endsWith("/")) {
-                        url = url.substring(0, url.length() - 1);
-                    }
-                    return url;
-                };
+                urlProvider = params -> String.valueOf(params[index]);
             } else if (parameters[i].isAnnotationPresent(QueryParams.class)) {
                 final QueryParams params = parameters[i].getAnnotation(QueryParams.class);
                 queryParamsProvider.queries.put(i, new QueryEncodable("", params.encode(), params.format()));

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/service/HttpClientFactoryImplTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/service/HttpClientFactoryImplTest.java
@@ -423,7 +423,7 @@ class HttpClientFactoryImplTest {
             server.start();
             final GenericClient httpClient = newDefaultFactory().create(GenericClient.class, null);
             Response<byte[]> response = httpClient
-                    .execute(2000, 2000, "http://localhost:" + server.getAddress().getPort() + "/api/", "POST", null,
+                    .execute(2000, 2000, "http://localhost:" + server.getAddress().getPort() + "/api", "POST", null,
                             null, null);
             assertEquals("POST@Authorization=Basic ABCD/Connection=keep-alive@/api@", new String(response.body()));
         } finally {
@@ -432,7 +432,7 @@ class HttpClientFactoryImplTest {
     }
 
     @Test
-    void requestGenericIgnorePath() throws IOException {
+    void requestGenericDoNotIgnorePath() throws IOException {
         final HttpServer server = createTestServer(HttpURLConnection.HTTP_OK);
         try {
             server.start();
@@ -445,7 +445,7 @@ class HttpClientFactoryImplTest {
             final GenericClient httpClient = newDefaultFactory().create(GenericClient.class, null);
             Response<byte[]> response = httpClient
                     .doNotEncodeQueryParams("http://localhost:" + server.getAddress().getPort() + "/api/", queries);
-            assertEquals("PUT@Connection=keep-alive@/api?param=value@", new String(response.body()));
+            assertEquals("PUT@Connection=keep-alive@/api/?param=value@", new String(response.body()));
         } finally {
             server.stop(0);
         }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-1722

Removing last slash in user input is, IMHO, not a good thing. Having an ending slash has a particular meaning in REST resources so not reflecting the user's initial intent.