### PR TITLE
Upgrade netty to v4.1.58.Final and ensure default http testing module is java 11 friendly over ssl

### DIFF
--- a/component-runtime-testing/component-runtime-http-junit/pom.xml
+++ b/component-runtime-testing/component-runtime-http-junit/pom.xml
@@ -28,7 +28,7 @@
   <description>JUnit integration to simplify the HTTP API testing/mocking.</description>
 
   <properties>
-    <netty.version>5.0.0.Alpha2</netty.version>
+    <netty.version>4.1.58.Final</netty.version>
     <talend.build.name>${talend.build.name.base}.junit.http</talend.build.name>
   </properties>
 

--- a/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/DefaultResponseLocatorCapturingHandler.java
+++ b/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/DefaultResponseLocatorCapturingHandler.java
@@ -25,9 +25,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
 
 import org.talend.sdk.component.junit.http.api.HttpApiHandler;
@@ -51,11 +48,8 @@ public class DefaultResponseLocatorCapturingHandler extends PassthroughHandler {
         requestModel.setMethod(request.method().name().toString());
         requestModel.setUri(requestUri);
         requestModel
-                .setHeaders(filterHeaders(StreamSupport
-                        .stream(Spliterators
-                                .spliteratorUnknownSize(request.headers().iteratorConverted(), Spliterator.IMMUTABLE),
-                                false)
-                        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue))));
+                .setHeaders(filterHeaders(
+                        request.headers().entries().stream().collect(toMap(Map.Entry::getKey, Map.Entry::getValue))));
         final DefaultResponseLocator.Model model = new DefaultResponseLocator.Model();
         model.setRequest(requestModel);
 

--- a/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/HandlerImpl.java
+++ b/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/HandlerImpl.java
@@ -138,6 +138,8 @@ public class HandlerImpl<T extends HttpApiHandler<?>> implements AutoCloseable {
                         HttpsURLConnection.setDefaultSSLSocketFactory(defaultSslContext.getSocketFactory());
                         HttpsURLConnection.setDefaultHostnameVerifier(defaultHostnameVerifier);
                     }, shutdown);
+                    shutdown = decorate(
+                            () -> setProperty("jdk.internal.httpclient.disableHostnameVerification", "true"), shutdown);
 
                     SSLContext.setDefault(handler.getSslContext());
                     HttpsURLConnection.setDefaultSSLSocketFactory(handler.getSslContext().getSocketFactory());

--- a/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/PassthroughHandler.java
+++ b/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/PassthroughHandler.java
@@ -49,10 +49,10 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
@@ -67,12 +67,12 @@ public class PassthroughHandler extends SimpleChannelInboundHandler<FullHttpRequ
     protected final HttpApiHandler api;
 
     @Override
-    protected void messageReceived(final ChannelHandlerContext ctx, final FullHttpRequest request) {
+    protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest request) {
         if (HttpMethod.CONNECT.name().equalsIgnoreCase(request.method().name())) {
             final FullHttpResponse response =
                     new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER);
-            HttpHeaderUtil.setKeepAlive(response, true);
-            HttpHeaderUtil.setContentLength(response, 0);
+            HttpUtil.setKeepAlive(response, true);
+            HttpUtil.setContentLength(response, 0);
             if (api.getSslContext() != null) {
                 final SSLEngine sslEngine = api.getSslContext().createSSLEngine();
                 sslEngine.setUseClientMode(false);
@@ -113,10 +113,7 @@ public class PassthroughHandler extends SimpleChannelInboundHandler<FullHttpRequ
                     httpsURLConnection.setHostnameVerifier((h, s) -> true);
                     httpsURLConnection.setSSLSocketFactory(api.getSslContext().getSocketFactory());
                 }
-                request
-                        .headers()
-                        .entries()
-                        .forEach(e -> connection.setRequestProperty(e.getKey().toString(), e.getValue().toString()));
+                request.headers().entries().forEach(e -> connection.setRequestProperty(e.getKey(), e.getValue()));
                 if (request.method() != null) {
                     final String requestMethod = request.method().name().toString();
                     connection.setRequestMethod(requestMethod);
@@ -157,7 +154,7 @@ public class PassthroughHandler extends SimpleChannelInboundHandler<FullHttpRequ
             final ByteBuf bytes = ofNullable(resp.payload()).map(Unpooled::copiedBuffer).orElse(Unpooled.EMPTY_BUFFER);
             final HttpResponse response =
                     new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(resp.status()), bytes);
-            HttpHeaderUtil.setContentLength(response, bytes.array().length);
+            HttpUtil.setContentLength(response, bytes.array().length);
 
             Stream
                     .of(resp.headers(), otherHeaders)

--- a/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/ServingProxyHandler.java
+++ b/component-runtime-testing/component-runtime-http-junit/src/main/java/org/talend/sdk/component/junit/http/internal/impl/ServingProxyHandler.java
@@ -43,11 +43,11 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.Attribute;
@@ -63,7 +63,7 @@ public class ServingProxyHandler extends SimpleChannelInboundHandler<FullHttpReq
     private final HttpApiHandler api;
 
     @Override
-    protected void messageReceived(final ChannelHandlerContext ctx, final FullHttpRequest request) {
+    protected void channelRead0(final ChannelHandlerContext ctx, final FullHttpRequest request) {
         if (!request.decoderResult().isSuccess()) {
             sendError(ctx, HttpResponseStatus.BAD_REQUEST);
             return;
@@ -74,8 +74,7 @@ public class ServingProxyHandler extends SimpleChannelInboundHandler<FullHttpReq
         api.getExecutor().execute(() -> {
             final Map<String, String> headers = StreamSupport
                     .stream(Spliterators
-                            .spliteratorUnknownSize(request.headers().iteratorConverted(), Spliterator.IMMUTABLE),
-                            false)
+                            .spliteratorUnknownSize(request.headers().iteratorAsString(), Spliterator.IMMUTABLE), false)
                     .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
             final Attribute<String> baseAttr = ctx.channel().attr(Handlers.BASE);
             Optional<Response> matching = api
@@ -115,7 +114,7 @@ public class ServingProxyHandler extends SimpleChannelInboundHandler<FullHttpReq
             final ByteBuf bytes = ofNullable(resp.payload()).map(Unpooled::copiedBuffer).orElse(Unpooled.EMPTY_BUFFER);
             final HttpResponse response =
                     new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(resp.status()), bytes);
-            HttpHeaderUtil.setContentLength(response, bytes.array().length);
+            HttpUtil.setContentLength(response, bytes.array().length);
 
             if (!api.isSkipProxyHeaders()) {
                 response.headers().set("X-Talend-Proxy-JUnit", "true");


### PR DESCRIPTION
### Requirements

https://jira.talendforge.org/browse/TCOMP-1852

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build

No code change, tests already there

* Any API addition **MUST** be done with a documentation update if relevant 

No change

### Why this PR is needed?

The netty shade in http testing module uses an old netty version not supporting java 11 (take care netty 5 alpha is "pre" most of the v4 now).

### What does this PR adds (design/code thoughts)?

* It enables to disable unsafe usage on java 11 (-Dorg.talend.__shade__.io.netty.noUnsafe=true) and therefore avoid java >= 11 illegal access errors/warnings
* It sets the system property to disable host name verification of java 11 http client (not always sufficient but best effort, worse case user has to set it in its system properties/pom)
