### PR TITLE
fix(TCOMP-1935) after variables

### DIFF
--- a/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/visitor/ModelVisitor.java
+++ b/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/visitor/ModelVisitor.java
@@ -22,13 +22,19 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.talend.sdk.component.api.component.AfterVariables.AfterVariable;
 import org.talend.sdk.component.api.component.AfterVariables.AfterVariableContainer;
 import org.talend.sdk.component.api.input.Assessor;
 import org.talend.sdk.component.api.input.Emitter;
@@ -47,6 +53,11 @@ import org.talend.sdk.component.api.standalone.RunAtDriver;
 import org.talend.sdk.component.runtime.reflect.Parameters;
 
 public class ModelVisitor {
+
+    private static final Set<Class<?>> SUPPORTED_AFTER_VARIABLES_TYPES = new HashSet<>(
+            Arrays.asList(Boolean.class, Byte.class, byte[].class, Character.class, Date.class, Double.class, Float.class,
+                    BigDecimal.class, Integer.class, Long.class, Object.class, Short.class, String.class, List.class)
+    );
 
     public void visit(final Class<?> type, final ModelListener listener, final boolean validate) {
         if (getSupportedComponentTypes().noneMatch(type::isAnnotationPresent)) { // unlikely but just in case
@@ -140,6 +151,7 @@ public class ModelVisitor {
                     }
                 });
 
+        validateAfterVariableAnnotationDeclaration(type);
         validateAfterVariableContainer(type);
     }
 
@@ -154,6 +166,7 @@ public class ModelVisitor {
             throw new IllegalArgumentException(producers.get(0) + " must not have any parameter");
         }
 
+        validateAfterVariableAnnotationDeclaration(input);
         validateAfterVariableContainer(input);
     }
 
@@ -170,6 +183,7 @@ public class ModelVisitor {
             throw new IllegalArgumentException(driverRunners.get(0) + " must not have any parameter");
         }
 
+        validateAfterVariableAnnotationDeclaration(standalone);
         validateAfterVariableContainer(standalone);
     }
 
@@ -218,6 +232,7 @@ public class ModelVisitor {
             }
         });
 
+        validateAfterVariableAnnotationDeclaration(input);
         validateAfterVariableContainer(input);
     }
 
@@ -296,4 +311,15 @@ public class ModelVisitor {
                 && paramType.getActualTypeArguments()[1].equals(Object.class);
     }
 
+    private static void validateAfterVariableAnnotationDeclaration(final Class<?> type) {
+        List<String> incorrectDeclarations = Stream.of(type.getAnnotationsByType(AfterVariable.class))
+                .filter(annotation -> !SUPPORTED_AFTER_VARIABLES_TYPES.contains(annotation.type()))
+                .map(annotation -> "Key '" + annotation.value() + "' has incorrect type: '" + annotation.type() + "'")
+                .collect(toList());
+        if (!incorrectDeclarations.isEmpty()) {
+            String message = incorrectDeclarations.stream()
+                    .collect(Collectors.joining(",", "The after variables declared incorrectly. ", ""));
+            throw new IllegalArgumentException(message);
+        }
+    }
 }

--- a/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/visitor/ModelVisitor.java
+++ b/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/visitor/ModelVisitor.java
@@ -54,10 +54,9 @@ import org.talend.sdk.component.runtime.reflect.Parameters;
 
 public class ModelVisitor {
 
-    private static final Set<Class<?>> SUPPORTED_AFTER_VARIABLES_TYPES = new HashSet<>(
-            Arrays.asList(Boolean.class, Byte.class, byte[].class, Character.class, Date.class, Double.class, Float.class,
-                    BigDecimal.class, Integer.class, Long.class, Object.class, Short.class, String.class, List.class)
-    );
+    private static final Set<Class<?>> SUPPORTED_AFTER_VARIABLES_TYPES = new HashSet<>(Arrays
+            .asList(Boolean.class, Byte.class, byte[].class, Character.class, Date.class, Double.class, Float.class,
+                    BigDecimal.class, Integer.class, Long.class, Object.class, Short.class, String.class, List.class));
 
     public void visit(final Class<?> type, final ModelListener listener, final boolean validate) {
         if (getSupportedComponentTypes().noneMatch(type::isAnnotationPresent)) { // unlikely but just in case
@@ -312,12 +311,15 @@ public class ModelVisitor {
     }
 
     private static void validateAfterVariableAnnotationDeclaration(final Class<?> type) {
-        List<String> incorrectDeclarations = Stream.of(type.getAnnotationsByType(AfterVariable.class))
+        List<String> incorrectDeclarations = Stream
+                .of(type.getAnnotationsByType(AfterVariable.class))
                 .filter(annotation -> !SUPPORTED_AFTER_VARIABLES_TYPES.contains(annotation.type()))
-                .map(annotation -> "Key '" + annotation.value() + "' has incorrect type: '" + annotation.type() + "'")
+                .map(annotation -> "The after variable with name '" + annotation.value() + "' has incorrect type: '"
+                        + annotation.type() + "'")
                 .collect(toList());
         if (!incorrectDeclarations.isEmpty()) {
-            String message = incorrectDeclarations.stream()
+            String message = incorrectDeclarations
+                    .stream()
                     .collect(Collectors.joining(",", "The after variables declared incorrectly. ", ""));
             throw new IllegalArgumentException(message);
         }

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/visitor/visitor/ModelVisitorTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/visitor/visitor/ModelVisitorTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.talend.sdk.component.api.component.AfterVariables.AfterVariable;
 import org.talend.sdk.component.api.component.AfterVariables.AfterVariableContainer;
 import org.talend.sdk.component.api.input.Assessor;
 import org.talend.sdk.component.api.input.Emitter;
@@ -45,6 +46,7 @@ import org.talend.sdk.component.api.standalone.DriverRunner;
 import org.talend.sdk.component.api.standalone.RunAtDriver;
 import org.talend.sdk.component.runtime.visitor.ModelListener;
 import org.talend.sdk.component.runtime.visitor.ModelVisitor;
+import org.talend.sdk.component.runtime.visitor.visitor.ModelVisitorTest.MapperAfterVariableNokWrongDeclaredType.Mapper;
 import org.talend.sdk.component.runtime.visitor.visitor.ModelVisitorTest.Registrar.In;
 
 class ModelVisitorTest {
@@ -141,6 +143,11 @@ class ModelVisitorTest {
     @Test
     void processorAfterVariableNokWrongParamCount() {
         assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokWrongParamCount.class));
+
+    }
+    @Test
+    void processorAfterVariableNokWrongDeclaredType() {
+        assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokWrongDeclaredType.class));
     }
 
     @Test
@@ -152,6 +159,11 @@ class ModelVisitorTest {
     @Test
     void emitterAfterVariableNokWrongReturnType() {
         assertThrows(IllegalArgumentException.class, () -> visit(EmitterAfterVariableNokWrongReturnType.class));
+    }
+
+    @Test
+    void emitterAfterVariableNokWrongDeclaredType() {
+        assertThrows(IllegalArgumentException.class, () -> visit(EmitterAfterVariableNokWrongDeclaredType.class));
     }
 
     @Test
@@ -168,6 +180,11 @@ class ModelVisitorTest {
     @Test
     void mapperAfterVariableNokWrongReturnType() {
         assertThrows(IllegalArgumentException.class, () -> visit(MapperAfterVariableNokWrongReturnType.class));
+    }
+
+    @Test
+    void mapperAfterVariableNokWrongDeclaredType() {
+        assertThrows(IllegalArgumentException.class, () -> visit(MapperAfterVariableNokWrongDeclaredType.class));
     }
 
     @Test
@@ -199,6 +216,11 @@ class ModelVisitorTest {
     @Test
     void standaloneAfterVariableNokWrongReturnType() {
         assertThrows(IllegalArgumentException.class, () -> visit(StandaloneAfterVariableNokWrongReturnType.class));
+    }
+
+    @Test
+    void standaloneAfterVariableNokWrongDeclaredType() {
+        assertThrows(IllegalArgumentException.class, () -> visit(StandaloneAfterVariableNokWrongDeclaredType.class));
     }
 
     @Test
@@ -557,6 +579,24 @@ class ModelVisitorTest {
         }
     }
 
+    public static class ProcessorAfterVariableNokWrongDeclaredType {
+
+        @AfterVariable(value = "Name", type = Mapper.class)
+        @Processor(family = "comp", name = "Output")
+        public static class Out {
+
+            @AfterVariableContainer
+            public Map<String, Object> container() {
+                return Collections.emptyMap();
+            }
+
+            @AfterGroup
+            public void commit(final Collection<Record> records) {
+                // no-op
+            }
+        }
+    }
+
     public static class EmitterAfterVariableOk {
 
         @Emitter(family = "comp", name = "Input")
@@ -598,6 +638,24 @@ class ModelVisitorTest {
 
             @AfterVariableContainer
             public Map<String, Object> commit(String param) {
+                return Collections.emptyMap();
+            }
+
+            @Producer
+            public Record emit() {
+                return null;
+            }
+        }
+    }
+
+    public static class EmitterAfterVariableNokWrongDeclaredType {
+
+        @AfterVariable(value = "Name", type = Mapper.class)
+        @Emitter(family = "comp", name = "Input")
+        public static class In {
+
+            @AfterVariableContainer
+            public Map<String, Object> container() {
                 return Collections.emptyMap();
             }
 
@@ -689,6 +747,34 @@ class ModelVisitorTest {
         }
     }
 
+    public static class MapperAfterVariableNokWrongDeclaredType {
+
+        @AfterVariable(value = "Name", type = Mapper.class)
+        @PartitionMapper(family = "comp", name = "Mapper")
+        public static class Mapper {
+
+            @Assessor
+            public long get() {
+                return 1;
+            }
+
+            @Split
+            public Collection<Mapper> ins() {
+                return emptyList();
+            }
+
+            @Emitter
+            public In emit() {
+                return null;
+            }
+
+            @AfterVariableContainer
+            public Map<String, Object> container() {
+                return Collections.emptyMap();
+            }
+        }
+    }
+
     public static class StandaloneNoRunMethod {
 
         @DriverRunner
@@ -746,6 +832,24 @@ class ModelVisitorTest {
 
             @AfterVariableContainer
             public Map<String, String> commit() {
+                return Collections.emptyMap();
+            }
+
+            @RunAtDriver
+            public Record emit() {
+                return null;
+            }
+        }
+    }
+
+    public static class StandaloneAfterVariableNokWrongDeclaredType {
+
+        @AfterVariable(value = "Name", type = Mapper.class)
+        @DriverRunner(family = "comp", name = "standalone")
+        public static class Standalone {
+
+            @AfterVariableContainer
+            public Map<String, Object> container() {
                 return Collections.emptyMap();
             }
 

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/visitor/visitor/ModelVisitorTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/visitor/visitor/ModelVisitorTest.java
@@ -136,8 +136,26 @@ class ModelVisitorTest {
     }
 
     @Test
-    void processorAfterVariableNokWrongReturnType() {
-        assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokWrongReturnType.class));
+    void processorAfterVariableNokWrongContainerReturnType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> visit(ProcessorAfterVariableNokWrongContainerReturnType.class));
+    }
+
+    @Test
+    void processorAfterVariableNokWrongContainerReturnParameterizedDimension() {
+        assertThrows(IllegalArgumentException.class,
+                () -> visit(ProcessorAfterVariableNokWrongContainerReturnParameterizedDimension.class));
+    }
+
+    @Test
+    void processorAfterVariableNokWrongContainerReturnParameterizedType() {
+        assertThrows(IllegalArgumentException.class,
+                () -> visit(ProcessorAfterVariableNokWrongContainerReturnParameterizedType.class));
+    }
+
+    @Test
+    void processorAfterVariableNokMoreThanOneContainer() {
+        assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokMoreThanOneContainer.class));
     }
 
     @Test
@@ -145,6 +163,7 @@ class ModelVisitorTest {
         assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokWrongParamCount.class));
 
     }
+
     @Test
     void processorAfterVariableNokWrongDeclaredType() {
         assertThrows(IllegalArgumentException.class, () -> visit(ProcessorAfterVariableNokWrongDeclaredType.class));
@@ -530,6 +549,7 @@ class ModelVisitorTest {
 
     public static class ProcessorAfterVariableOk {
 
+        @AfterVariable(value = "NAME", type = Integer.class)
         @Processor(family = "comp", name = "Output")
         public static class Out {
 
@@ -545,13 +565,71 @@ class ModelVisitorTest {
         }
     }
 
-    public static class ProcessorAfterVariableNokWrongReturnType {
+    public static class ProcessorAfterVariableNokWrongContainerReturnType {
+
+        @AfterVariable(value = "NAME", type = Integer.class)
+        @Processor(family = "comp", name = "Output")
+        public static class Out {
+
+            @AfterVariableContainer
+            public String commit() {
+                return "It should be Map<String, Object>";
+            }
+
+            @AfterGroup
+            public void commit(final Collection<Record> records) {
+                // no-op
+            }
+        }
+    }
+
+    public static class ProcessorAfterVariableNokWrongContainerReturnParameterizedDimension {
+
+        @AfterVariable(value = "NAME", type = Integer.class)
+        @Processor(family = "comp", name = "Output")
+        public static class Out {
+
+            @AfterVariableContainer
+            public Collection<String> commit() {
+                return Collections.emptyList();
+            }
+
+            @AfterGroup
+            public void commit(final Collection<Record> records) {
+                // no-op
+            }
+        }
+    }
+
+    public static class ProcessorAfterVariableNokWrongContainerReturnParameterizedType {
 
         @Processor(family = "comp", name = "Output")
         public static class Out {
 
             @AfterVariableContainer
             public Map<String, String> commit() {
+                return Collections.emptyMap();
+            }
+
+            @AfterGroup
+            public void commit(final Collection<Record> records) {
+                // no-op
+            }
+        }
+    }
+
+    public static class ProcessorAfterVariableNokMoreThanOneContainer {
+
+        @Processor(family = "comp", name = "Output")
+        public static class Out {
+
+            @AfterVariableContainer
+            public Map<String, Object> container1() {
+                return Collections.emptyMap();
+            }
+
+            @AfterVariableContainer
+            public Map<String, Object> container2() {
                 return Collections.emptyMap();
             }
 
@@ -599,6 +677,7 @@ class ModelVisitorTest {
 
     public static class EmitterAfterVariableOk {
 
+        @AfterVariable(value = "NAME", type = Integer.class)
         @Emitter(family = "comp", name = "Input")
         public static class In {
 
@@ -668,6 +747,7 @@ class ModelVisitorTest {
 
     public static class MapperAfterVariableOk {
 
+        @AfterVariable(value = "NAME", type = Integer.class)
         @PartitionMapper(family = "comp", name = "Mapper")
         public static class Mapper {
 
@@ -810,6 +890,7 @@ class ModelVisitorTest {
 
     public static class StandaloneAfterVariableOk {
 
+        @AfterVariable(value = "NAME", type = Integer.class)
         @DriverRunner(family = "comp", name = "standalone")
         public static class Standalone {
 

--- a/documentation/src/main/antora/modules/ROOT/pages/javajet-to-componentkit.adoc
+++ b/documentation/src/main/antora/modules/ROOT/pages/javajet-to-componentkit.adoc
@@ -399,6 +399,11 @@ Component Kit
 import org.talend.sdk.component.api.component.AfterVariables.AfterVariableContainer;
 import org.talend.sdk.component.api.component.AfterVariables.AfterVariable;
 
+/**
+* Possible types:
+* Boolean.class, Byte.class, byte[].class, Character.class, Date.class, Double.class, Float.class,
+* BigDecimal.class, Integer.class, Long.class, Object.class, Short.class, String.class, List.class
+*/
 @AfterVariable(value = "NAME_1_OF_AFTER_VARIABLE", description = "Some description", type = Integer.class)
 @AfterVariable(value = "NAME_2_OF_AFTER_VARIABLE", description = "Custom variable description", type = String.class)
 class Emitter {


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
Fix of After Variables Feature.

### What does this PR adds (design/code thoughts)?
https://jira.talendforge.org/browse/TCOMP-1935
It adds validation of what types the connector-writer can use when defines After variables.
I think List-type is still a tricky one and maybe a backdoor for us. But at least it's supported by
https://github.com/Talend/studio-tools/blob/12808863466ad7adecc3e24efe9db8c5489fd825/org.talend.cloud.publisher/src/main/java/org/talend/core/model/metadata/types/JavaTypesManager.java
