### PR TITLE
Security chore(): Switch SAST Scan from sandbox to dedicated Application

### DIFF
--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -92,16 +92,16 @@ spec:
                 container('main') {
                     withCredentials([veracodeCredentials, nexusCredentials]) {
                         sh "mvn -B -s .jenkins/settings.xml package $SKIP_OPTS"
-                        veracode applicationName: "$VERACODE_APP_NAME",
+                        veracode applicationName: "$VERACODE_SANDBOX",
+                            teams: "Components",
                             canFailJob: true,
-                            createProfile: false,
+                            createProfile: true,
+                            criticality: "High",
                             debug: true,
                             copyRemoteFiles: true,
                             fileNamePattern: '',
                             useProxy: false,
                             replacementPattern: '',
-                            sandboxName: "$VERACODE_SANDBOX",
-                            createSandbox: true,
                             scanExcludesPattern: '',
                             scanIncludesPattern: '',
                             scanName: "master-${currentBuild.number}-${currentBuild.startTimeInMillis}",


### PR DESCRIPTION
We've now got more licenses, and microservices can use their own application, so you don't loose work like a sandbox when it expires !
If you need dedicated branch scanning, use the sandboxes for that instead.

**What is the problem this PR is trying to solve?**
SAST scans are performed in a sandbox that expires and loses work.

**What is the chosen solution to this problem?**
SAST scans are now automatically creating an application, based on the previous sandbox name.

**Please check if the PR fulfills these requirements**
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
