### PR TITLE
feat(TCOMP-2016): UISchema titleMap supports advanced datalist

### DIFF
--- a/component-form/component-form-core/src/test/java/org/talend/sdk/component/form/api/UiSpecServiceTest.java
+++ b/component-form/component-form-core/src/test/java/org/talend/sdk/component/form/api/UiSpecServiceTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.json.bind.Jsonb;
@@ -645,7 +646,11 @@ class UiSpecServiceTest {
 
                             assertNotNull(driver.getTriggers());
                             assertEquals(1, driver.getTriggers().size());
-                            final Collection<UiSchema.NameValue> titleMap = driver.getTitleMap();
+                            final Collection<UiSchema.NameValue> titleMap = driver
+                                    .getTitleMap()
+                                    .stream()
+                                    .map(UiSchema.NameValue.class::cast)
+                                    .collect(Collectors.toList());
                             assertEquals(1, titleMap.size());
                             final UiSchema.NameValue firstTitleMap = titleMap.iterator().next();
                             assertEquals("some.driver.Jdbc", firstTitleMap.getValue());

--- a/component-form/component-form-model/src/main/java/org/talend/sdk/component/form/model/uischema/UiSchema.java
+++ b/component-form/component-form-model/src/main/java/org/talend/sdk/component/form/model/uischema/UiSchema.java
@@ -67,7 +67,7 @@ public class UiSchema {
 
     private Collection<Trigger> triggers;
 
-    private Collection<NameValue> titleMap;
+    private Collection<? extends TitleMapContent> titleMap;
 
     private Map<String, Collection<Object>> condition;
 
@@ -198,8 +198,46 @@ public class UiSchema {
         }
     }
 
+    public interface TitleMapContent {
+
+    }
+
     @Data
-    public static class NameValue {
+    public static class TitledNameValue implements TitleMapContent {
+
+        private String title;
+
+        private Collection<NameValue> suggestions;
+
+        public static final class Builder {
+
+            private String title;
+
+            private Collection<NameValue> suggestions;
+
+            public TitledNameValue.Builder withTitle(final String title) {
+                this.title = title;
+                return this;
+            }
+
+            public TitledNameValue.Builder withSuggestions(final Collection<NameValue> nameValue) {
+                this.suggestions = nameValue;
+                return this;
+            }
+
+            public TitledNameValue build() {
+                final TitledNameValue titledNameValue = new TitledNameValue();
+                titledNameValue.setTitle(title);
+                titledNameValue.setSuggestions(suggestions);
+                return titledNameValue;
+            }
+
+        }
+
+    }
+
+    @Data
+    public static class NameValue implements TitleMapContent {
 
         private String name;
 
@@ -433,7 +471,7 @@ public class UiSchema {
 
         private Collection<Trigger> triggers;
 
-        private Collection<NameValue> titleMap;
+        private Collection<? extends TitleMapContent> titleMap;
 
         private Map<String, Collection<Object>> condition;
 
@@ -577,14 +615,11 @@ public class UiSchema {
             return withTitleMap(asList(titleMap));
         }
 
-        public Builder withTitleMap(final Collection<NameValue> titleMap) {
+        public Builder withTitleMap(final Collection<? extends TitleMapContent> titleMap) {
             if (titleMap == null) {
                 return this;
             }
-            if (this.titleMap == null) {
-                this.titleMap = new ArrayList<>();
-            }
-            this.titleMap.addAll(titleMap);
+            this.titleMap = new ArrayList<>(titleMap);
             return this;
         }
 


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

See https://jira.talendforge.org/browse/TCOMP-2016

### What does this PR adds (design/code thoughts)?

The titleMap, which was strongly typed, is now more generic, and supports different types of content. Those types are all implementations of a new empty interface `TitleMapContent`. `NameValue` now implements this interface and this PR comes with a second concrete implementation usuful to support the advanced datalist. Example of usage can be found in the unit tests.
