### PR TITLE
TCOMP-2019 : fix complete entry collision

### DIFF
--- a/component-api/src/main/java/org/talend/sdk/component/api/record/Schema.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/record/Schema.java
@@ -456,7 +456,8 @@ public interface Schema {
             final Supplier<Stream<Schema.Entry>> allEntriesSupplier, final BiConsumer<String, Entry> replaceFunction) {
         final Optional<Entry> collisionedEntry = allEntriesSupplier //
                 .get() //
-                .filter((final Entry field) -> field.getName().equals(newEntry.getName())) //
+                .filter((final Entry field) -> field.getName().equals(newEntry.getName())
+                        && !Objects.equals(field, newEntry)) //
                 .findFirst();
         if (!collisionedEntry.isPresent()) {
             // No collision, return new entry.

--- a/component-api/src/test/java/org/talend/sdk/component/api/record/SchemaTest.java
+++ b/component-api/src/test/java/org/talend/sdk/component/api/record/SchemaTest.java
@@ -267,7 +267,7 @@ class SchemaTest {
         final Schema.Entry realEntry2 =
                 Schema.avoidCollision(e2, entriesDuplicate.values()::stream, entriesDuplicate::put);
 
-        Assertions.assertNull(realEntry2);
+        Assertions.assertSame(realEntry2, e2);
     }
 
     private Entry newEntry(final String name, final String defaultValue) {

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
@@ -490,4 +490,21 @@ class RecordBuilderImplTest {
                 .withMetadata(true)
                 .build();
     }
+
+    @Test
+    void testUsedSameEntry() {
+        final RecordImpl.BuilderImpl builder = new RecordImpl.BuilderImpl();
+        final Schema.Entry e1 = new Entry.Builder().withName("_0000").withType(Type.STRING).build();
+
+        builder.withString(e1, "value1");
+        final Schema.Entry e2 =
+                new Entry.Builder().withName("_0001").withRawName("_0000_number").withType(Type.STRING).build();
+        builder.withString(e2, "value2");
+        builder.withString(e2, "value3");
+        final Record record = builder.build();
+        Assertions.assertNotNull(record);
+
+        Assertions.assertEquals("value3", record.getString("_0001"));
+        Assertions.assertEquals(2, record.getSchema().getEntries().size());
+    }
 }

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/SchemaImplTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/SchemaImplTest.java
@@ -193,7 +193,12 @@ class SchemaImplTest {
                                         .filter((Entry e) -> Objects.equals(name, e.getName())))
                                 .count());
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> this.newSchema(entry3, entry3));
+        final Entry entry3Twin = new Entry.Builder() //
+                .withName("name_b") //
+                .withType(Type.LONG) //
+                .withDefaultValue(0L) //
+                .build();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> this.newSchema(entry3, entry3Twin));
     }
 
     private Schema newSchema(Entry... entries) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-2019
Fix when call twice "withEntry(entry, XX)" with same entry.
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
