### PR TITLE
fix(TCOMP-2102): Fix javadoc to repare build

### DIFF
--- a/talend-component-maven-plugin/src/main/java/org/talend/sdk/component/maven/ComponentDependenciesBase.java
+++ b/talend-component-maven-plugin/src/main/java/org/talend/sdk/component/maven/ComponentDependenciesBase.java
@@ -118,7 +118,11 @@ public abstract class ComponentDependenciesBase extends AudienceAwareMojo {
      * <li>if not found, searches online with
      * {@link ComponentDependenciesBase#resolveArtifactOnRemoteRepositories(Artifact)}</li>
      * </ul>
-     * The provided classifier & type override the artifact's.
+     * The provided classifier &amp; type override the artifact's.
+     *
+     * @param artifact The artifact to resolve
+     * @param classifier The classifier of the artifact to resolve
+     * @param type The type of the artifact to resolve
      */
     protected Artifact resolveArtifact(final Artifact artifact, final String classifier, final String type) {
         final LocalRepositoryManager lrm = repositorySystemSession.getLocalRepositoryManager();
@@ -155,6 +159,8 @@ public abstract class ComponentDependenciesBase extends AudienceAwareMojo {
      * <li>downloads it in the local maven repository</li>
      * <li>throws if any step above can't be done</li>
      * </ul>
+     *
+     * @param artifact The artifact to resolve
      */
     protected Artifact resolveArtifactOnRemoteRepositories(final Artifact artifact) {
         final String gav = computeCoordinates(artifact);


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

The build on `master` is broken.

### What does this PR adds (design/code thoughts)?

Fix the build.

### :warning: This fix is incomplete

We should always build the javadoc (or never, but here I believe we need it).

Currently, it is only built on 4 modules (added manually in their poms) when not on `master`: 

* `component-api`
* `component-runtime-junit`
* `component-runtime-beam-junit`
* `component-runtime-http-junit`

The issue is that I haven't found why yet. 

The javadoc is built:

* [partially on dev branches](https://jenkins-connectors.datapwn.com/job/component-runtime/job/build/job/master__TDI-2102_fixCloudComponentsBuild/7/consoleFull)
* [fully on master](https://jenkins-connectors.datapwn.com/job/component-runtime/job/build/job/master/522/consoleFull)

But the Maven commend that's run is the same in both cases: `mvn clean install -Dgpg.skip=true -Denforcer.skip=true -s .jenkins/settings.xml`

Can we dig a bit to make sure other people don't get caught in this trap? @undx
