### PR TITLE
Use https instead of ssh

### DIFF
--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -232,7 +232,8 @@ pipeline {
                 [$class: 'RelativeTargetDirectory', relativeTargetDir: './connectors'],
                 [$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true]
             ],
-            userRemoteConfigs: [[credentialsId: 'github-ssh', url: 'git@github.com:Talend/connectors-se.git']]
+            userRemoteConfigs: [[credentialsId: '"github-credentials"',
+                                 url: 'https://github.com/Talend/connectors-se.git']]
         ])
       }
     }


### PR DESCRIPTION
### Why this PR is needed?
To stop to use the old ssh credentials on the Jenkins instance

