### PR TITLE
chore(TCOMP-2269): Junit publisher fix 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -343,6 +343,11 @@ spec:
                 recordIssues(
                     enabledForFailure: true,
                     tools: [
+                        junitParser(
+                          id: 'unit-test',
+                          name: 'Unit Test',
+                          pattern: '**/target/surefire-reports/*.xml'
+                        ),
                         taskScanner(
                             id: 'disabled',
                             name: '@Disabled',


### PR DESCRIPTION
https://jira.talendforge.org/browse/TCOMP-2269
### Why this PR is needed?
The Jenkins job missed JUnit result publishing.

### What does this PR adds (design/code thoughts)?
Add JUnit publisher in the "always" step.