### PR TITLE
fix(TCOMP-2241): use Beam-aware classloader to run ProducerFinder pipeline

### DIFF
--- a/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/BeamProducerFinder.java
+++ b/component-runtime-beam/src/main/java/org/talend/sdk/component/runtime/beam/spi/BeamProducerFinder.java
@@ -88,7 +88,7 @@ public class BeamProducerFinder extends ProducerFinderImpl {
                 final PTransform<PBegin, PCollection<Record>> transform) {
             super(delegate, rootName, name, plugin);
             this.transform = transform;
-            result = init();
+            result = runDataReadingPipeline();
         }
 
         @Override
@@ -121,14 +121,38 @@ public class BeamProducerFinder extends ProducerFinderImpl {
             return record;
         }
 
-        private PipelineResult init() {
-            PipelineOptions options = PipelineOptionsFactory.create();
-            PushRecord pushRecord = new PushRecord();
-            ParDo.SingleOutput<Record, Void> of = ParDo.of(pushRecord);
-            Pipeline p = Pipeline.create(options);
-            p.apply(transform).apply(of);
+        /**
+         * <p>Runs a pipeline to read data from an input connector implemented using Beam APIs.</p>
+         * <p>
+         * Explicit care must be taken to use the appropriate class loader before running
+         * the pipeline, as the underlying {@link org.apache.beam.sdk.options.PipelineOptions.DirectRunner}
+         * must dynamically find some service implementations using the {@link java.util.ServiceLoader} API.
+         * </p>
+         * <p>Not specifying the appropriate classloader can lead to weird exceptions like:</p>
+         * <pre>
+         * No translator known for org.apache.beam.repackaged.direct_java.runners.core.construction.SplittableParDo$PrimitiveBoundedRead
+         * </pre>
+         *
+         * <p><i>Note: the input connector code is in fact correctly called in its dedicated classloader thanks the
+         * various TCK framework wrappers that are in place.</i></p>
+         */
+        private PipelineResult runDataReadingPipeline() {
+            final ClassLoader beamAwareClassLoader = Pipeline.class.getClassLoader();
+            final ClassLoader callerClassLoader = Thread.currentThread().getContextClassLoader();
 
-            return p.run();
+            try {
+                Thread.currentThread().setContextClassLoader(beamAwareClassLoader);
+
+                PipelineOptions options = PipelineOptionsFactory.create();
+                PushRecord pushRecord = new PushRecord();
+                ParDo.SingleOutput<Record, Void> of = ParDo.of(pushRecord);
+                Pipeline p = Pipeline.create(options);
+                p.apply(transform).apply(of);
+
+                return p.run();
+            } finally {
+                Thread.currentThread().setContextClassLoader(callerClassLoader);
+            }
         }
 
         private void sleep() {


### PR DESCRIPTION
## What's the problem?

🐛  _Issues_:
* TDP functional bug: https://jira.talendforge.org/browse/TDP-11429
* TCOMP technical bug: https://jira.talendforge.org/browse/TCOMP-2241


🗒️  _Summary_:

Impossibility of using the "join" (also named "lookup") capability of TDP (in the ongoing "Runtime Convergence" project) when the joined Dataset is implemented using Beam APIs and not fully in TCK.

It's the case for the Datasets of these types (at least, there are probably more):

- Local file
- S3
- ...

💥 _Log_:

A log has been spotted in Livy

```
No translator known for org.apache.beam.repackaged.direct_java.runners.core.construction.SplittableParDo$PrimitiveBoundedRead
```

## Chosen solution

Explicitely run "Join" Beam pipeline in the application classloader (see below for full explanation)

## Detailed rationale

### A word about TCK connectors & classloaders

First, it's important to talk about the fact that TCK components are running in a semi-isolated classloader. This classloader (which we'll refer as the _component classloader_) is still child of the application classloader, with some specific filtering in place. There is a dedicated _component classloader_ per-component (makes sense, they might have similar dependencies but in different versions, we want them to be isolated).

```mermaid
flowchart BT
    bootstrapCl[Bootstrap Class Loader]
    platformCl[Platform Class Loader]
    appCl[Application Class Loader]
    compXCl[Component X Class Loader]
    compYCl[Component Y Class Loader]
    compXCl-- Filtering --->appCl
    compYCl-- Filtering --->appCl
    appCl --> platformCl
    platformCl --> bootstrapCl
```

This filtering makes total sense: the runtime might use Apache Beam and plenty other libraries, but From the TCK component point of view, all of this has to be an implementation detail. We don't want all of the application classloader classes to be shared.

> :bulb: Basically, only TCK API classes are shared with the component classloaders, like `Record`... However, one can extend the list of shared classes through the `Customizer` SPI and its `containerClassesAndPackages` method.


### Reading data from another Dataset in a TCK component

The [`ProducerFinder`](https://github.com/Talend/component-runtime/blob/master/component-api/src/main/java/org/talend/sdk/component/api/service/source/ProducerFinder.java) service & interface has been introduced a few months ago to explicitely offer the ability to read some Dataset data (using it's input connector, a `Record`  *producer*) from within another component.

Functionally, one of it's use-case is the "join" (or "lookup") feature in Data Preparation: you're able to join another Dataset's data to the preparation. This function, just like all TDP functions, is implemented within the `processing-functions` component as a TCK processor.

Implementations of this new `ProducerFinder` service are discovered using a SPI, or fallback to a default implementation. It turns out that the default implementation is only able to instantiate TCK-based input components.

One major issue we had is that some older components are not pure TCK-based, but implemented using Beam APIs (Local file, S3, ...)

To overcome this, a new `BeamProducerFinder` implementation of `ProducerFinder` has been introduced (in the `component-runtime-beam` module), which is capable of reading data from Beam-based input components. How? By running an in-memory Beam pipeline. Running a pipeline in-memory is a bit different than our normal usecase: it uses a different Beam Runner called a `DirectRunner` (while the "real" pipelines use a `SparkRunner`).

To run, this `DirectRunner` needs to load some implementations of a few interfaces (for reasons we won't detail). To do so, as Beam is extensible, it sometimes leverages the `ServiceLoader` API to find implementations for these classes.

When the pipeline is actually ran in the  `DirectRunner` pipeline, the executing thread class current classloader is the _component classloader_, not the _application classloader_ (again, it makes perfect sense, we're actually in the component execution context).

But because of the filtering, the `ServiceLoader` API can't find Beam's SPI implementations, because their corresponding service configuration file in `META-INF/services` is not accessible from the _component classloader_. While one can specify which classloader to use when calling `ServiceLoader.load`  , the code which does this is deep inside Beam DirectRunner implementation and thus out of our reach.

### The bug

This causes the following stack-trace

```
Caused by: java.lang.IllegalStateException: No translator known for org.apache.beam.repackaged.direct_java.runners.core.construction.SplittableParDo$PrimitiveBoundedRead
o.a.l.u.LineBufferedStream - stdout: 	at org.apache.beam.repackaged.direct_java.runners.core.construction.PTransformTranslation.urnForTransform(PTransformTranslation.java:283) ~[beam-runners-direct-java-2.36.0.jar:?]
o.a.l.u.LineBufferedStream - stdout: 	at org.apache.beam.runners.direct.RootProviderRegistry.getInitialInputs(RootProviderRegistry.java:73) ~[beam-runners-direct-java-2.36.0.jar:?]
```


### Solution divergence

```mermaid
flowchart LR
    solution([<b>Solution</b>])
    haveBeamResourcesAvailable(Have Beam resources available<br>in component classloader)
    duplicateBeamServicesDefinition(Duplicate Beam services<br>definition in TDP module)
    configureSharedResourcesList(Configure the list of<br>shared resources)
    executeJoinPipelineInAppCL(Execute 'Join' Beam pipeline<br>in app classloader)
    preferredSolution>"🏆 <i>Preferred</i>"]
    hackSolution>"☢️ <i>Temporary fix for TDP</i>"]
    notSoGoodSolution>"💣 <i>Breaks component encapsulation</i>"]

    solution --> haveBeamResourcesAvailable
    haveBeamResourcesAvailable --> duplicateBeamServicesDefinition
    haveBeamResourcesAvailable --> configureSharedResourcesList
    solution --> executeJoinPipelineInAppCL
    
    executeJoinPipelineInAppCL --> preferredSolution
    duplicateBeamServicesDefinition --> hackSolution
    configureSharedResourcesList --> notSoGoodSolution

    style preferredSolution fill:#F1F8E9
    style solution fill:#E3F2FD
    style hackSolution fill:#FFF8E1
    style notSoGoodSolution fill:#FFEBEE
```



#### ☢ Duplicate Beam services definition in TDP functions module: dirty & easy

One possibility is to duplicate Beam's `META-INF/services` files in the `processing-functions` module resources. This will work, even if they reference classes which are not accessible from the _component classloader_ because the class which calls the `ServiceLoader` API was actually loaded from the _application classloader_.

This is what will be done at first for the [TDP-11429](https://jira.talendforge.org/browse/TDP-11429) issue to unlock the join/lookup function (we're on a tight schedule!)

#### 💣 Configure the list of shared resources between application & component classloaders

One fix I considered was to use the existing capability of TCK to tweak the list of resources which are filtered between the application classloader and the component's one.

This is possible through the use of files named `TALEND-INF/org.talend.sdk.component.container.ContainerManager.jvmMarkers.txt` . In such a file, one can declare the `beam-runners-direct-java` JAR and it will allow its corresponding resources to be shared.

```
beam-runners-direct-java-${beam.version}.jar
```

The downside of this fix is that is breaks the encapsulation between application & component classloader. Beam (classes & resources) should not be visible to component classloader. Ultimately it's not a big deal, since the component will probably never access these on-purpose, but it feels like a hack...

#### 🏆 Explicitely run "Join" Beam pipeline in the application classloader

Currently, the "Join" Beam pipeline is ran in the caller classloader, in our case the `processing-functions` component's one.

One solution to fix the issue is to make sure that the pipeline is run in the application classloader (and of course restore the current thread classloader just after). With this change, Beam `DirectRunner` will have no trouble finding the appropriate resources and the pipeline will run fine.

There is also no problem of calling the input connector with the wrong classloader, as the magical classloader dance will happen at some point before reaching the input emitter (hint: set a breakpoint in `Thread#setContextClassLoader` to see the magic happen).

This is probably the best & most straightforward fix, as it does not involve breaking encapsulation and only affects the clients of the `ProducerFinder` service.
