### PR TITLE
chore(TDP-11601): backport entry name order fix to TCK 1.50

### DIFF
--- a/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/record/RecordImpl.java
+++ b/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/record/RecordImpl.java
@@ -233,6 +233,10 @@ public final class RecordImpl implements Record {
                 }
                 this.entries.replace(name, schemaEntry);
 
+                if (this.orderState != null) {
+                    this.orderState.orderedEntries.replace(name, schemaEntry);
+                }
+
                 this.values.remove(name);
                 this.values.put(schemaEntry.getName(), value);
                 return this;

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
@@ -542,13 +542,15 @@ class RecordBuilderImplTest {
 
         // Then order is preserved in the builder
         Assertions.assertEquals(3, builder.getCurrentEntries().size());
-        final List<String> builderEntriesName = builder.getCurrentEntries().stream().map(Entry::getName).collect(Collectors.toList());
+        final List<String> builderEntriesName =
+                builder.getCurrentEntries().stream().map(Entry::getName).collect(Collectors.toList());
         assertEquals(Arrays.asList("firstColumn_renamed", "secondColumn", "thirdColumn"), builderEntriesName);
 
         // Then order is also preserved in the built Record
         final Record outputRecord = builder.build();
         final Schema outputRecordSchema = outputRecord.getSchema();
-        final List<String> outputEntriesName = outputRecordSchema.getEntriesOrdered().stream().map(Schema.Entry::getName).collect(Collectors.toList());
+        final List<String> outputEntriesName =
+                outputRecordSchema.getEntriesOrdered().stream().map(Schema.Entry::getName).collect(Collectors.toList());
 
         assertEquals(Arrays.asList("firstColumn_renamed", "secondColumn", "thirdColumn"), outputEntriesName);
     }

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
@@ -529,6 +529,31 @@ class RecordBuilderImplTest {
     }
 
     @Test
+    void updateEntryByName_preservesOrder() {
+        // Given
+        final Record.Builder builder = new RecordImpl.BuilderImpl()
+                .withString("firstColumn", "hello")
+                .withInt("secondColumn", 20)
+                .withString("thirdColumn", "foo");
+
+        // When
+        final Entry renamedEntry = newEntry("firstColumn_renamed", Type.STRING);
+        builder.updateEntryByName("firstColumn", renamedEntry);
+
+        // Then order is preserved in the builder
+        Assertions.assertEquals(3, builder.getCurrentEntries().size());
+        final List<String> builderEntriesName = builder.getCurrentEntries().stream().map(Entry::getName).collect(Collectors.toList());
+        assertEquals(Arrays.asList("firstColumn_renamed", "secondColumn", "thirdColumn"), builderEntriesName);
+
+        // Then order is also preserved in the built Record
+        final Record outputRecord = builder.build();
+        final Schema outputRecordSchema = outputRecord.getSchema();
+        final List<String> outputEntriesName = outputRecordSchema.getEntriesOrdered().stream().map(Schema.Entry::getName).collect(Collectors.toList());
+
+        assertEquals(Arrays.asList("firstColumn_renamed", "secondColumn", "thirdColumn"), outputEntriesName);
+    }
+
+    @Test
     void withRecordFromEntryWithNullValue() {
         final Entry recordEntry = new EntryImpl.BuilderImpl()
                 .withType(Type.RECORD)


### PR DESCRIPTION
Backport of #655 to maintenance branch for TCK 1.50 (which will be used by TDP for EAP)