### PR TITLE
chore(TDI-48973): Fix Sonar NoClassDefFoundError

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,6 +269,7 @@ pipeline {
                             // TODO Disabling Sonar cache due to "ClassNotFoundException: com.google.common.collect.LinkedListMultimap" issue
                             //  (https://community.sonarsource.com/t/sonarscanner-for-maven-broken-with-sonarqube-9-5/67061/8), try to remove
                             //  these lines on next SonarQube upgrade (9.7.1+)
+                            //  https://jira.talendforge.org/browse/TDI-48980 (CI: Reactivate Sonar cache)
                             sh "_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED' mvn -Dsonar.host.url=https://sonar-eks.datapwn.com -Dsonar.login='$SONAR_USER' -Dsonar.password='$SONAR_PASS' -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.analysisCache.enabled=false sonar:sonar"
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -266,7 +266,10 @@ pipeline {
                     }
                     withCredentials([sonarCredentials]) {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            sh "_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED' mvn -Dsonar.host.url=https://sonar-eks.datapwn.com -Dsonar.login='$SONAR_USER' -Dsonar.password='$SONAR_PASS' -Dsonar.branch.name=${env.BRANCH_NAME} sonar:sonar"
+                            // TODO Disabling Sonar cache due to "ClassNotFoundException: com.google.common.collect.LinkedListMultimap" issue
+                            //  (https://community.sonarsource.com/t/sonarscanner-for-maven-broken-with-sonarqube-9-5/67061/8), try to remove
+                            //  these lines on next SonarQube upgrade (9.7.1+)
+                            sh "_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED' mvn -Dsonar.host.url=https://sonar-eks.datapwn.com -Dsonar.login='$SONAR_USER' -Dsonar.password='$SONAR_PASS' -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.analysisCache.enabled=false sonar:sonar"
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -266,10 +266,7 @@ pipeline {
                     }
                     withCredentials([sonarCredentials]) {
                         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                            // TODO Disabling Sonar cache due to "ClassNotFoundException: com.google.common.collect.LinkedListMultimap" issue
-                            //  (https://community.sonarsource.com/t/sonarscanner-for-maven-broken-with-sonarqube-9-5/67061/8), try to remove
-                            //  these lines on next SonarQube upgrade (9.7.1+)
-                            //  https://jira.talendforge.org/browse/TDI-48980 (CI: Reactivate Sonar cache)
+                            // TODO https://jira.talendforge.org/browse/TDI-48980 (CI: Reactivate Sonar cache)
                             sh "_JAVA_OPTIONS='--add-opens=java.base/java.lang=ALL-UNNAMED' mvn -Dsonar.host.url=https://sonar-eks.datapwn.com -Dsonar.login='$SONAR_USER' -Dsonar.password='$SONAR_PASS' -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.analysisCache.enabled=false sonar:sonar"
                         }
                     }


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
Sonar checks fail with "java.lang.NoClassDefFoundError: com/google/common/collect/LinkedListMultimap$1KeySetImpl"

### What does this PR adds (design/code thoughts)?
https://jira.talendforge.org/browse/TDI-48973

Following SFT bump of Sonar in 9.6, builds are failing with:
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/common/collect/LinkedListMultimap$1KeySetImpl

This is linked to a bug on 9.6 using Sonar cache.

It is fixed in 9.7.1, however there is another blocker for SFT to stay on version 9.6 for the time being.