### PR TITLE
chore(TCOMP-2331): Fix Antora duplicate nav exception

### DIFF
--- a/documentation/src/main/antora/site-template.yml
+++ b/documentation/src/main/antora/site-template.yml
@@ -48,6 +48,8 @@ content:
       - '!component-runtime-1.38.3'
       - '!component-runtime-1.38.4'
       - '!component-runtime-1.38.5'
+      - '!component-runtime-1.38.6'
+      - '!component-runtime-1.38.7'
       - '!component-runtime-1.39.0'
       - '!component-runtime-1.39.1'
       - '!component-runtime-1.39.2'


### PR DESCRIPTION
Exclude non latest maintenance versions from antora documentation generation process. Followed recommandations from:
https://wiki.talend.com/pages/viewpage.action?spaceKey=rd&title=component-runtime+release+process#componentruntimereleaseprocess-Documentationstepisfailingduetoantoraexception

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
Documentation build is failing with Antora duplicate nav exception following 2 recent maintenance releases which were not excluded.

### What does this PR adds (design/code thoughts)?
Exclude 1.38.6 and 1.38.7 from the list of versions for Antora.

https://jira.talendforge.org/browse/TCOMP-2331