### PR TITLE
fix(TCOMP-2371): [TCK JDBC]: Studio dynamic column metadata info : isKey should follow runtime dynamic object, not the input component's studio schema

### DIFF
--- a/component-studio/component-runtime-di/src/main/java/org/talend/sdk/component/runtime/di/record/DiRowStructVisitor.java
+++ b/component-studio/component-runtime-di/src/main/java/org/talend/sdk/component/runtime/di/record/DiRowStructVisitor.java
@@ -325,7 +325,7 @@ public class DiRowStructVisitor {
                         final String metaName = sanitizeConnectionName(meta.getName());
                         final String metaOriginalName = meta.getDbName();
                         final boolean metaIsNullable = meta.isNullable();
-                        final boolean metaIsKey = meta.isKey() ? meta.isKey() : isKey;
+                        final boolean metaIsKey = meta.isKey();
                         final int metaLength = meta.getLength() != -1 ? meta.getLength() : length;
                         final int metaPrecision = meta.getPrecision() != -1 ? meta.getPrecision() : precision;
                         final String metaPattern =

--- a/component-studio/component-runtime-di/src/test/java/org/talend/sdk/component/runtime/di/record/DiRowStructVisitorTest.java
+++ b/component-studio/component-runtime-di/src/test/java/org/talend/sdk/component/runtime/di/record/DiRowStructVisitorTest.java
@@ -47,9 +47,15 @@ import lombok.Data;
 class DiRowStructVisitorTest extends VisitorsTest {
 
     private void createMetadata(final Dynamic dynamic, final String name, final String type, final Object value) {
+        createMetadata(dynamic, name, type, value, false);
+    }
+
+    private void createMetadata(final Dynamic dynamic, final String name, final String type, final Object value,
+            boolean isKey) {
         final DynamicMetadata meta = new DynamicMetadata();
         meta.setName(name);
         meta.setType(type);
+        meta.setKey(isKey);
         dynamic.metadatas.add(meta);
         dynamic.addColumnValue(value);
     }
@@ -81,7 +87,7 @@ class DiRowStructVisitorTest extends VisitorsTest {
         rowStruct.char0 = Character.MAX_VALUE;
         // dynamic
         final Dynamic dynamic = new Dynamic();
-        createMetadata(dynamic, "dynString", StudioTypes.STRING, "stringy");
+        createMetadata(dynamic, "dynString", StudioTypes.STRING, "stringy", true);
         createMetadata(dynamic, "dynInteger", StudioTypes.INTEGER, INT);
         createMetadata(dynamic, "dynDouble", StudioTypes.DOUBLE, DOUBLE);
         createMetadata(dynamic, "dynBytes", StudioTypes.BYTE_ARRAY, BYTES0);
@@ -131,6 +137,7 @@ class DiRowStructVisitorTest extends VisitorsTest {
         assertEquals("true", schema.getEntry("dynString").getProp(IS_KEY));
         assertEquals(StudioTypes.STRING, schema.getEntry("dynString").getProp(STUDIO_TYPE));
         assertEquals("dYnAmIc", schema.getEntry("dynString").getComment());
+        assertEquals("false", schema.getEntry("dynDouble").getProp(IS_KEY));
         assertEquals(StudioTypes.DOUBLE, schema.getEntry("dynDouble").getProp(STUDIO_TYPE));
         assertEquals("30", schema.getEntry("dynDouble").getProp(SIZE));
         assertEquals("10", schema.getEntry("dynDouble").getProp(SCALE));


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
https://jira.talendforge.org/browse/TCOMP-2371

### What does this PR adds (design/code thoughts)?
https://jira.talendforge.org/browse/TCOMP-2371