### PR TITLE
chore(TCOMP-2367) - Phase out layerspector and migrate to JIB

### DIFF
--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -24,8 +24,8 @@
 /**
  * Pod configuration
  */
-final String _TSBI_IMAGE = 'jdk11-svc-springboot-builder'
-final String _TSBI_VERSION = '2.9.18-2.4-20220104141654'
+final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_VERSION = '3.0.8-20220928070500'
 final String _STAGE_DEFAULT_CONTAINER = _TSBI_IMAGE
 final String _POD_LABEL = ((String) "tck-api-test-${UUID.randomUUID().toString()}").take(53)
 


### PR DESCRIPTION
### Why this PR is needed?
To phase out layerspector and migrate to JIB

### What does this PR adds (design/code thoughts)?
Align TCK API Test Jenkins pod runner image with build image to jdk17-svc-builder
