### PR TITLE
feat(TCOMP-2367) phase out layerspector for build and scan scripts

### DIFF
--- a/.jenkins/jenkins_pod.yml
+++ b/.jenkins/jenkins_pod.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+spec:
+  imagePullSecrets:
+    - name: talend-registry
+  containers:
+    - name: main
+      # 3.0.9-20220930152032 is the last root version of custom-builder
+      image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/custom-builder:3.0.9-20220930152032'
+      command: [ cat ]
+      tty: true
+      volumeMounts: [
+        { name: efs-jenkins-component-runtime-m2, mountPath: /root/.m2/repository},
+        { name: efs-jenkins-connectors-asdf, mountPath: /root/.asdf/installs, subPath: installs }
+      ]
+      resources: {requests: {memory: 6G, cpu: '4.0'}, limits: {memory: 8G, cpu: '5.0'}}
+      env:
+        - name: DOCKER_HOST
+          value: tcp://localhost:2375
+    - name: docker-daemon
+      image: artifactory.datapwn.com/docker-io-remote/docker:19.03.1-dind
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ""
+      securityContext:
+        privileged: true
+  volumes:
+    - name: efs-jenkins-component-runtime-m2
+      persistentVolumeClaim:
+        claimName: efs-jenkins-component-runtime-m2
+    - name: efs-jenkins-connectors-asdf
+      persistentVolumeClaim:
+        claimName: efs-jenkins-connectors-asdf

--- a/.jenkins/scripts/asdf_install.sh
+++ b/.jenkins/scripts/asdf_install.sh
@@ -18,21 +18,9 @@
 set -xe
 
 main() {
-  # force creation of gnupg folder by listing private keys and export it
-  gpg -k
-  export GPG_DIR="${HOME}/.gnupg"
-  # work folders
-  mkdir -p .build .build_source
-  # decrypt keys
-  openssl enc -aes256 -d -v \
-          -iv  "$KEY_USER" \
-          -K   "$KEY_PASS" \
-          -in  .travis/encrypted.tar.gz.enc \
-          -out .build_source/encrypted.tar.gz
-  tar xvzf .build_source/encrypted.tar.gz -C .build
-  cp  -v  .build/gpg/travis.* "$GPG_DIR/"
-  # import key
-  gpg --import --no-tty --batch --yes "$GPG_DIR/travis.priv.bin"
+ asdf install
+ asdf reshim
+ asdf current
 }
 
 main "$@"

--- a/.jenkins/scripts/package.sh
+++ b/.jenkins/scripts/package.sh
@@ -17,14 +17,13 @@
 
 set -xe
 
-# Parameters:
-# $1: skips options
+# This script allow to package the current project with maven on specific jenkins provided settings.xml
+# You can provide extra parameters to tune maven
+# $1: extra_mvn_parameters
 main() {
-  _POM_FILE_PATH="${1?Missing pom_file_path}"; shift
-  SKIP_OPTS=("$@")
+  _EXTRA_MVN_PARAMETERS=("$@")
   
-  mvn package --batch-mode --settings .jenkins/settings.xml ${SKIP_OPTS[*]}
-
+  mvn package --batch-mode --settings .jenkins/settings.xml ${_EXTRA_MVN_PARAMETERS[*]}
 }
 
 main "$@"

--- a/.jenkins/scripts/package.sh
+++ b/.jenkins/scripts/package.sh
@@ -17,22 +17,14 @@
 
 set -xe
 
+# Parameters:
+# $1: skips options
 main() {
-  # force creation of gnupg folder by listing private keys and export it
-  gpg -k
-  export GPG_DIR="${HOME}/.gnupg"
-  # work folders
-  mkdir -p .build .build_source
-  # decrypt keys
-  openssl enc -aes256 -d -v \
-          -iv  "$KEY_USER" \
-          -K   "$KEY_PASS" \
-          -in  .travis/encrypted.tar.gz.enc \
-          -out .build_source/encrypted.tar.gz
-  tar xvzf .build_source/encrypted.tar.gz -C .build
-  cp  -v  .build/gpg/travis.* "$GPG_DIR/"
-  # import key
-  gpg --import --no-tty --batch --yes "$GPG_DIR/travis.priv.bin"
+  _POM_FILE_PATH="${1?Missing pom_file_path}"; shift
+  SKIP_OPTS=("$@")
+  
+  mvn package --batch-mode --settings .jenkins/settings.xml ${SKIP_OPTS[*]}
+
 }
 
 main "$@"

--- a/.jenkins/scripts/post-release.sh
+++ b/.jenkins/scripts/post-release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 #
 #  Copyright (C) 2006-2023 Talend Inc. - www.talend.com

--- a/.jenkins/scripts/release.sh
+++ b/.jenkins/scripts/release.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 #  Copyright (C) 2006-2023 Talend Inc. - www.talend.com
 #

--- a/.jenkins/scripts/veracode-sca.sh
+++ b/.jenkins/scripts/veracode-sca.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+#  Copyright (C) 2006-2023 Talend Inc. - www.talend.com
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+set -xe
+
+function usage(){
+  printf 'Run a Veracode SCA (Source Clear Analysis)\n'
+  printf 'Usage : %s <srcclr_api_token>\n' "${0}"
+  printf '\n'
+  printf '%s\n' "${1}"
+  printf '\n'
+  exit 1
+}
+
+# Parameters:
+[ -z ${1+x} ] && usage 'Parameter "srcclr_api_token" is needed.'
+
+_SRCCLR_API_TOKEN=${1}
+
+main() (
+  printf '##############################################\n'
+  printf 'Veracode SCA (Source Clear Analysis)\n'
+  printf '##############################################\n'
+
+  veracode_sca
+)
+
+function veracode_sca {
+
+  cp .jenkins/settings.xml ~/.m2/
+  curl -sSL https://download.sourceclear.com/ci.sh | SRCCLR_API_TOKEN=${_SRCCLR_API_TOKEN} DEBUG=1 sh -s -- scan --allow-dirty --recursive --skip-collectors npm;
+
+}
+
+main "$@"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+java adoptopenjdk-17.0.2+8
+maven 3.8.5

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-java adoptopenjdk-17.0.2+8
+java adoptopenjdk-17.0.5+8
 maven 3.8.5

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ final Boolean isMasterBranch = env.BRANCH_NAME == "master"
 final Boolean isStdBranch = (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("maintenance/"))
 final Boolean hasPostLoginScript = params.POST_LOGIN_SCRIPT != ""
 final Boolean hasExtraBuildArgs = params.EXTRA_BUILD_ARGS != ""
-final String tsbiImage = "artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/jdk17-svc-builder:3.0.8-20220928070500"
-final String podLabel = "component-runtime-${UUID.randomUUID().toString()}".take(53)
+final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_VERSION = '3.1.9-20230228074507'
 final String buildTimestamp = String.format('-%tY%<tm%<td%<tH%<tM%<tS', java.time.LocalDateTime.now())
 
 // Files and folder definition
@@ -48,7 +48,7 @@ final String podDefinition = """\
         - name: talend-registry
       containers:
         - name: main
-          image: '${tsbiImage}'
+          image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/${_TSBI_IMAGE}:${_TSBI_VERSION}'
           command: [ cat ]
           tty: true
           volumeMounts: [
@@ -74,8 +74,8 @@ final String podDefinition = """\
 pipeline {
     agent {
         kubernetes {
-            label podLabel
             yaml podDefinition
+            defaultContainer 'main'
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ final Boolean isMasterBranch = env.BRANCH_NAME == "master"
 final Boolean isStdBranch = (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("maintenance/"))
 final Boolean hasPostLoginScript = params.POST_LOGIN_SCRIPT != ""
 final Boolean hasExtraBuildArgs = params.EXTRA_BUILD_ARGS != ""
-final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_IMAGE = 'java17-base'
 final String _TSBI_VERSION = '3.1.9-20230228074507'
 final String buildTimestamp = String.format('-%tY%<tm%<td%<tH%<tM%<tS', java.time.LocalDateTime.now())
 

--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -80,62 +80,56 @@ pipeline {
     stages {
         stage('Post login') {
             steps {
-                container('main') {
-                    checkout([$class : 'GitSCM',
-                              branches: [[name: 'master']],
-                              extensions : [
-                                      [$class: 'CheckoutOption', timeout: 30],
-                                      [$class: 'CloneOption', depth: 30, noTags: true, shallow: true, timeout: 30]],
-                              userRemoteConfigs : [[url: 'https://github.com/Talend/component-runtime.git', credentialsId: 'github-credentials']]])
+                checkout([$class : 'GitSCM',
+                          branches: [[name: 'master']],
+                          extensions : [
+                                  [$class: 'CheckoutOption', timeout: 30],
+                                  [$class: 'CloneOption', depth: 30, noTags: true, shallow: true, timeout: 30]],
+                          userRemoteConfigs : [[url: 'https://github.com/Talend/component-runtime.git', credentialsId: 'github-credentials']]])
 
-                    script {
-                        try {
-                            sh """
-                                   bash .jenkins/scripts/npm_fix.sh
-                               """
-                        } catch (error) {
-                            //
-                        }
+                script {
+                    try {
+                        sh """
+                               bash .jenkins/scripts/npm_fix.sh
+                           """
+                    } catch (error) {
+                        //
                     }
                 }
             }
         }
         stage("SourceClear analysis") {
             steps {
-                container('main') {
-                    withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN'), nexusCredentials]) {
-                        sh '''#!/bin/bash
-                          cp .jenkins/settings.xml ~/.m2/
-                          curl -sSL https://download.sourceclear.com/ci.sh | SRCCLR_API_TOKEN=${SRCCLR_API_TOKEN} DEBUG=1 sh -s -- scan --allow-dirty --recursive --skip-collectors npm;
-                        '''
-                    }
+                withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN'), nexusCredentials]) {
+                    sh '''#!/bin/bash
+                      cp .jenkins/settings.xml ~/.m2/
+                      curl -sSL https://download.sourceclear.com/ci.sh | SRCCLR_API_TOKEN=${SRCCLR_API_TOKEN} DEBUG=1 sh -s -- scan --allow-dirty --recursive --skip-collectors npm;
+                    '''
                 }
             }
         }
         stage('Vera code') {
             steps {
-                container('main') {
-                    withCredentials([veracodeCredentials, nexusCredentials]) {
-                        sh "mvn -B -s .jenkins/settings.xml package $SKIP_OPTS"
-                        veracode applicationName: "$VERACODE_SANDBOX",
-                            teams: "Components",
-                            canFailJob: true,
-                            createProfile: true,
-                            criticality: "High",
-                            debug: true,
-                            copyRemoteFiles: true,
-                            fileNamePattern: '',
-                            useProxy: false,
-                            replacementPattern: '',
-                            scanExcludesPattern: '',
-                            scanIncludesPattern: '',
-                            scanName: "master-${currentBuild.number}-${currentBuild.startTimeInMillis}",
-                            uploadExcludesPattern: '**/.cache/**/*.jar,**/*dep*/**/*.jar,**/lib/**/*.jar,**/*repo*/**/*.jar,**/it/**/*.jar,**/sample*.jar',
-                            uploadIncludesPattern: '**/*.jar',
-                            waitForScan: true,
-                            vid: "$VERACODE_ID",
-                            vkey: "$VERACODE_KEY"
-                    }
+                withCredentials([veracodeCredentials, nexusCredentials]) {
+                    sh "mvn -B -s .jenkins/settings.xml package $SKIP_OPTS"
+                    veracode applicationName: "$VERACODE_SANDBOX",
+                        teams: "Components",
+                        canFailJob: true,
+                        createProfile: true,
+                        criticality: "High",
+                        debug: true,
+                        copyRemoteFiles: true,
+                        fileNamePattern: '',
+                        useProxy: false,
+                        replacementPattern: '',
+                        scanExcludesPattern: '',
+                        scanIncludesPattern: '',
+                        scanName: "master-${currentBuild.number}-${currentBuild.startTimeInMillis}",
+                        uploadExcludesPattern: '**/.cache/**/*.jar,**/*dep*/**/*.jar,**/lib/**/*.jar,**/*repo*/**/*.jar,**/it/**/*.jar,**/sample*.jar',
+                        uploadIncludesPattern: '**/*.jar',
+                        waitForScan: true,
+                        vid: "$VERACODE_ID",
+                        vkey: "$VERACODE_KEY"
                 }
             }
         }

--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -35,7 +35,15 @@ pipeline {
 
   environment {
     MAVEN_OPTS = '-Dmaven.artifact.threads=128 -Dorg.slf4j.simpleLogger.showThreadName=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss'
-    SKIP_OPTS = "-Dspotless.apply.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipTests -Dinvoker.skip=true -pl '!talend-component-kit-intellij-plugin' -pl '!reporting'"
+    // Maven package skipped elements
+    // Everything that is not needed for the veracode scan is excluded to reduce time
+    SKIP_OPTS = "-Dspotless.apply.skip=true\
+                 -Dcheckstyle.skip=true\
+                 -Drat.skip=true\
+                 -DskipTests\
+                 -Dinvoker.skip=true\
+                 -pl '!talend-component-kit-intellij-plugin'\
+                 -pl '!reporting'"
     TALEND_REGISTRY = 'registry.datapwn.com'
     VERACODE_APP_NAME = 'Components'
     VERACODE_SANDBOX = 'component-runtime'
@@ -121,6 +129,7 @@ pipeline {
       steps {
         withCredentials([veracodeCredentials, nexusCredentials]) {
           script {
+            // Execute a mvn package skipping not needed element
             sh "bash .jenkins/scripts/package.sh ${SKIP_OPTS}"
           }
         }

--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -14,132 +14,221 @@
  * limitations under the License.
  */
 final def slackChannel = 'components-ci'
-final def veracodeCredentials = usernamePassword(credentialsId: 'veracode-api-credentials', usernameVariable: 'VERACODE_ID', passwordVariable: 'VERACODE_KEY')
-final def nexusCredentials = usernamePassword(credentialsId: 'nexus-artifact-zl-credentials', usernameVariable: 'NEXUS_USER', passwordVariable: 'NEXUS_PASSWORD')
-final String _TSBI_IMAGE = 'java17-base'
-final String _TSBI_VERSION = '3.1.9-20230228074507'
+final def veracodeCredentials = usernamePassword(
+  credentialsId: 'veracode-api-credentials',
+  usernameVariable: 'VERACODE_ID',
+  passwordVariable: 'VERACODE_KEY')
+final def nexusCredentials = usernamePassword(
+  credentialsId: 'nexus-artifact-zl-credentials',
+  usernameVariable: 'NEXUS_USER',
+  passwordVariable: 'NEXUS_PASSWORD')
 
-
-final String _POD_CONFIGURATION = """
-  apiVersion: v1
-  kind: Pod
-  spec:
-    containers:
-      - name: 'main'
-        image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/${_TSBI_IMAGE}:${_TSBI_VERSION}'
-        command: [ cat ]
-        tty: true
-        volumeMounts: [
-          { name: docker, mountPath: /var/run/docker.sock },
-          { name: efs-jenkins-component-runtime-m2, mountPath: /root/.m2/repository },
-          { name: dockercache, mountPath: /root/.dockercache }
-        ]
-        resources: { requests: { memory: 3G, cpu: '2' }, limits: { memory: 8G, cpu: '2' }}
-    volumes:
-      - name: docker
-        hostPath: { path: /var/run/docker.sock }
-      - name: dockercache
-        hostPath: { path: /tmp/jenkins/tdi/docker }
-      - name: efs-jenkins-component-runtime-m2
-        persistentVolumeClaim:
-          claimName: efs-jenkins-component-runtime-m2
-      - name: efs-jenkins-component-runtime-download
-        persistentVolumeClaim:
-          claimName: efs-jenkins-component-runtime-download
-    imagePullSecrets:
-      - name: talend-registry
-"""
+String git_branch_name = ""
 
 pipeline {
-    agent {
-        kubernetes {
-            yaml _POD_CONFIGURATION
-            defaultContainer 'main'
-        }
+  agent {
+    kubernetes {
+      yamlFile '.jenkins/jenkins_pod.yml'
+      defaultContainer 'main'
     }
+  }
 
-    environment {
-        MAVEN_OPTS = '-Dmaven.artifact.threads=128 -Dorg.slf4j.simpleLogger.showThreadName=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss'
-        SKIP_OPTS="-Dspotless.apply.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipTests -Dinvoker.skip=true -pl '!talend-component-kit-intellij-plugin' -pl '!reporting'"
-        TALEND_REGISTRY = 'registry.datapwn.com'
-        VERACODE_APP_NAME = 'Components'
-        VERACODE_SANDBOX = 'component-runtime'
-        APP_ID = '579232'
-    }
+  environment {
+    MAVEN_OPTS = '-Dmaven.artifact.threads=128 -Dorg.slf4j.simpleLogger.showThreadName=true -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss'
+    SKIP_OPTS = "-Dspotless.apply.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipTests -Dinvoker.skip=true -pl '!talend-component-kit-intellij-plugin' -pl '!reporting'"
+    TALEND_REGISTRY = 'registry.datapwn.com'
+    VERACODE_APP_NAME = 'Components'
+    VERACODE_SANDBOX = 'component-runtime'
+    APP_ID = '579232'
+  }
 
-    options {
-        buildDiscarder(logRotator(artifactNumToKeepStr: '5', numToKeepStr: '5'))
-        timeout(time: 180, unit: 'MINUTES')
-        skipStagesAfterUnstable()
-    }
+  options {
+    buildDiscarder(logRotator(artifactNumToKeepStr: '5', numToKeepStr: '5'))
+    timeout(time: 180, unit: 'MINUTES')
+    skipStagesAfterUnstable()
+  }
 
-    triggers {
-        cron('0 6 * * 0')
-    }
+  parameters {
+    booleanParam(
+      name: 'VERACODE_SCA',
+      defaultValue: true,
+      description: 'Veracode SCA (Source Clear Analysis)')
+    booleanParam(
+      name: 'VERACODE_SAST',
+      defaultValue: true,
+      description: 'Veracode SAST (Static testing)')
+    booleanParam(
+      name: 'JENKINS_DEBUG',
+      defaultValue: false,
+      description: '''
+        Add an extra comportment to the job allowing analysis:
+          - keep the pod alive for debug purposes''')
+  }
 
-    stages {
-        stage('Post login') {
-            steps {
-                checkout([$class : 'GitSCM',
-                          branches: [[name: 'master']],
-                          extensions : [
-                                  [$class: 'CheckoutOption', timeout: 30],
-                                  [$class: 'CloneOption', depth: 30, noTags: true, shallow: true, timeout: 30]],
-                          userRemoteConfigs : [[url: 'https://github.com/Talend/component-runtime.git', credentialsId: 'github-credentials']]])
+  stages {
+    stage('Preliminary steps') {
+      steps {
+        ///////////////////////////////////////////
+        // Update build info
+        ///////////////////////////////////////////
+        script {
+          def scans = []
+          if (params.VERACODE_SCA) {
+            scans.add('SCA')
+          }
+          if (params.VERACODE_SAST) {
+            scans.add('SAST')
+          }
+          job_name_creation(scans.join('+'))
 
-                script {
-                    try {
-                        sh """
-                               bash .jenkins/scripts/npm_fix.sh
-                           """
-                    } catch (error) {
-                        //
-                    }
-                }
-            }
+          git_branch_name = "${env.GIT_BRANCH}".replace("origin/", "")
+          job_description_append("Scanned branch: ${git_branch_name}")
         }
-        stage("SourceClear analysis") {
-            steps {
-                withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN'), nexusCredentials]) {
-                    sh '''#!/bin/bash
-                      cp .jenkins/settings.xml ~/.m2/
-                      curl -sSL https://download.sourceclear.com/ci.sh | SRCCLR_API_TOKEN=${SRCCLR_API_TOKEN} DEBUG=1 sh -s -- scan --allow-dirty --recursive --skip-collectors npm;
-                    '''
-                }
-            }
+        ///////////////////////////////////////////
+        // asdf install
+        ///////////////////////////////////////////
+        script {
+          println "asdf install the content of repository .tool-versions'\n"
+          sh "bash .jenkins/scripts/asdf_install.sh"
         }
-        stage('Vera code') {
-            steps {
-                withCredentials([veracodeCredentials, nexusCredentials]) {
-                    sh "mvn -B -s .jenkins/settings.xml package $SKIP_OPTS"
-                    veracode applicationName: "$VERACODE_SANDBOX",
-                        teams: "Components",
-                        canFailJob: true,
-                        createProfile: true,
-                        criticality: "High",
-                        debug: true,
-                        copyRemoteFiles: true,
-                        fileNamePattern: '',
-                        useProxy: false,
-                        replacementPattern: '',
-                        scanExcludesPattern: '',
-                        scanIncludesPattern: '',
-                        scanName: "master-${currentBuild.number}-${currentBuild.startTimeInMillis}",
-                        uploadExcludesPattern: '**/.cache/**/*.jar,**/*dep*/**/*.jar,**/lib/**/*.jar,**/*repo*/**/*.jar,**/it/**/*.jar,**/sample*.jar',
-                        uploadIncludesPattern: '**/*.jar',
-                        waitForScan: true,
-                        vid: "$VERACODE_ID",
-                        vkey: "$VERACODE_KEY"
-                }
-            }
+        ///////////////////////////////////////////
+        // npm_fix TODO maybe not needed if not root
+        ///////////////////////////////////////////
+        script {
+          try {
+            sh "bash .jenkins/scripts/npm_fix.sh"
+          } catch (npm_error) {
+            println("error running npm_fix.sh: ${npm_error}")
+          }
         }
+      }
     }
-    post {
-        success {
-            slackSend(color: '#00FF00', message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})", channel: "${slackChannel}")
+    stage("Veracode SCA (Source Clear Analysis)") {
+      when {
+        expression { params.VERACODE_SCA }
+      }
+      steps {
+        withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN'),
+                        nexusCredentials]) {
+          sh "bash .jenkins/scripts/veracode-sca.sh $SRCCLR_API_TOKEN"
         }
-        failure {
-            slackSend(color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})", channel: "${slackChannel}")
-        }
+      }
     }
+    stage('Package the app for Static testing') {
+      when {
+        expression { params.VERACODE_SAST }
+      }
+      steps {
+        withCredentials([veracodeCredentials, nexusCredentials]) {
+          script {
+            sh "bash .jenkins/scripts/package.sh ${SKIP_OPTS}"
+          }
+        }
+      }
+    }
+    stage('Veracode SAST (Static testing)') {
+      when {
+        expression { params.VERACODE_SAST }
+      }
+      steps {
+        withCredentials([veracodeCredentials, nexusCredentials]) {
+          script {
+            veracode applicationName: "$VERACODE_SANDBOX",
+              teams: "Components",
+              canFailJob: true,
+              createProfile: true,
+              criticality: "High",
+              debug: true,
+              copyRemoteFiles: true,
+              fileNamePattern: '',
+              useProxy: false,
+              replacementPattern: '',
+              scanExcludesPattern: '',
+              scanIncludesPattern: '',
+              scanName: "${git_branch_name}-${currentBuild.number}-${currentBuild.startTimeInMillis}",
+              uploadExcludesPattern: '**/.cache/**/*.jar,**/*dep*/**/*.jar,**/lib/**/*.jar,**/*repo*/**/*.jar,**/it/**/*.jar,**/sample*.jar',
+              uploadIncludesPattern: '**/*.jar',
+              waitForScan: true,
+              vid: "$VERACODE_ID",
+              vkey: "$VERACODE_KEY"
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      script {
+        if (params.JENKINS_DEBUG) {
+          jenkinsBreakpoint()
+        }
+      }
+    }
+    success {
+      slackSend(
+        color: '#00FF00',
+        message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+        channel: "${slackChannel}")
+    }
+    failure {
+      slackSend(color: '#FF0000',
+        message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+        channel: "${slackChannel}")
+    }
+  }
+}
+
+/**
+ * Append a new line to job description
+ * REM This is MARKDOWN, do not forget double space at the end of line
+ *
+ * @param new line
+ * @return void
+ */
+private void job_name_creation(String extra) {
+  String user_name = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause').userId[0]
+  if (user_name == null) {
+      user_name = "auto"
+  }
+
+  currentBuild.displayName = (
+    "#$currentBuild.number-$extra-$user_name"
+  )
+}
+
+/**
+ * Append a new line to job description
+ * REM This is MARKDOWN, do not forget double space at the end of line
+ *
+ * @param new line
+ * @return void
+ */
+private void job_description_append(String new_line) {
+  if (currentBuild.description == null) {
+    println "Create the job description with: \n$new_line"
+    currentBuild.description = new_line
+  } else {
+    println "Edit the job description adding: $new_line"
+    currentBuild.description = currentBuild.description + '\n' + new_line
+  }
+}
+
+/**
+ * Implement a simple breakpoint to stop actual job
+ * Use the method anywhere you need to stop
+ * The first usage is to keep the pod alive on post stage.
+ * Change and restore the job description to be more visible
+ *
+ * @param job_description_to_backup
+ * @return void
+ */
+private void jenkinsBreakpoint() {
+  // Backup the description
+  String job_description_backup = currentBuild.description
+  // updating build description
+  currentBuild.description = "ACTION NEEDED TO CONTINUE \n ${job_description_backup}"
+  // Request user action
+  input message: 'Finish the job?', ok: 'Yes'
+  // updating build description
+  currentBuild.description = "$job_description_backup"
 }

--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -16,42 +16,45 @@
 final def slackChannel = 'components-ci'
 final def veracodeCredentials = usernamePassword(credentialsId: 'veracode-api-credentials', usernameVariable: 'VERACODE_ID', passwordVariable: 'VERACODE_KEY')
 final def nexusCredentials = usernamePassword(credentialsId: 'nexus-artifact-zl-credentials', usernameVariable: 'NEXUS_USER', passwordVariable: 'NEXUS_PASSWORD')
-final def tsbiImage = "artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/jdk17-svc-builder:3.0.8-20220928070500"
-final def podLabel = "component-runtime-scan-${UUID.randomUUID().toString()}".take(53)
+final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_VERSION = '3.1.9-20230228074507'
+
+
+final String _POD_CONFIGURATION = """
+  apiVersion: v1
+  kind: Pod
+  spec:
+    containers:
+      - name: 'main'
+        image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/${_TSBI_IMAGE}:${_TSBI_VERSION}'
+        command: [ cat ]
+        tty: true
+        volumeMounts: [
+          { name: docker, mountPath: /var/run/docker.sock },
+          { name: efs-jenkins-component-runtime-m2, mountPath: /root/.m2/repository },
+          { name: dockercache, mountPath: /root/.dockercache }
+        ]
+        resources: { requests: { memory: 3G, cpu: '2' }, limits: { memory: 8G, cpu: '2' }}
+    volumes:
+      - name: docker
+        hostPath: { path: /var/run/docker.sock }
+      - name: dockercache
+        hostPath: { path: /tmp/jenkins/tdi/docker }
+      - name: efs-jenkins-component-runtime-m2
+        persistentVolumeClaim:
+          claimName: efs-jenkins-component-runtime-m2
+      - name: efs-jenkins-component-runtime-download
+        persistentVolumeClaim:
+          claimName: efs-jenkins-component-runtime-download
+    imagePullSecrets:
+      - name: talend-registry
+"""
+
 pipeline {
     agent {
         kubernetes {
-            label podLabel
-            yaml """
-apiVersion: v1
-kind: Pod
-spec:
-    containers:
-        -
-            name: main
-            image: '${tsbiImage}'
-            command: [cat]
-            tty: true
-            volumeMounts: [
-                { name: docker, mountPath: /var/run/docker.sock }, 
-                { name: efs-jenkins-component-runtime-m2, mountPath: /root/.m2}, 
-                { name: dockercache, mountPath: /root/.dockercache}
-            ]
-            resources: {requests: {memory: 8G, cpu: '6.0'}, limits: {memory: 12G, cpu: '6.5'}}
-    volumes:
-        -
-            name: docker
-            hostPath: {path: /var/run/docker.sock}
-        -
-            name: efs-jenkins-component-runtime-m2
-            persistentVolumeClaim: 
-                claimName: efs-jenkins-component-runtime-m2
-        -
-            name: dockercache
-            hostPath: {path: /tmp/jenkins/component-runtime/docker}
-    imagePullSecrets:
-        - name: talend-registry
-"""
+            yaml _POD_CONFIGURATION
+            defaultContainer 'main'
         }
     }
 

--- a/ci/Jenkinsfile-scan
+++ b/ci/Jenkinsfile-scan
@@ -16,7 +16,7 @@
 final def slackChannel = 'components-ci'
 final def veracodeCredentials = usernamePassword(credentialsId: 'veracode-api-credentials', usernameVariable: 'VERACODE_ID', passwordVariable: 'VERACODE_KEY')
 final def nexusCredentials = usernamePassword(credentialsId: 'nexus-artifact-zl-credentials', usernameVariable: 'NEXUS_USER', passwordVariable: 'NEXUS_PASSWORD')
-final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_IMAGE = 'java17-base'
 final String _TSBI_VERSION = '3.1.9-20230228074507'
 
 

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -26,8 +26,6 @@
  */
 final String _TSBI_IMAGE = 'jdk17-svc-builder'
 final String _TSBI_VERSION = '3.1.9-20230228074507'
-final String _STAGE_DEFAULT_CONTAINER = _TSBI_IMAGE
-final String _POD_LABEL = ((String) "tck-api-test-${UUID.randomUUID().toString()}").take(53)
 
 /**
  * Job configuration
@@ -112,9 +110,8 @@ pipeline {
    */
   agent {
     kubernetes {
-      label _POD_LABEL
       yaml _POD_CONFIGURATION
-      defaultContainer _STAGE_DEFAULT_CONTAINER
+      defaultContainer _TSBI_IMAGE
     }
   }
   /**

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -24,8 +24,10 @@
 /**
  * Pod configuration
  */
-final String _TSBI_IMAGE = 'java17-base'
-final String _TSBI_VERSION = '3.1.9-20230228074507'
+final String _TSBI_IMAGE = 'jdk11-svc-springboot-builder'
+final String _TSBI_VERSION = '2.9.18-2.4-20220104141654'
+final String _STAGE_DEFAULT_CONTAINER = _TSBI_IMAGE
+final String _POD_LABEL = ((String) "tck-api-test-${UUID.randomUUID().toString()}").take(53)
 
 /**
  * Job configuration
@@ -49,7 +51,7 @@ final String _POD_CONFIGURATION = """
   kind: Pod
   spec:
     containers:
-      - name: main
+      - name: '${_TSBI_IMAGE}'
         image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/${_TSBI_IMAGE}:${_TSBI_VERSION}'
         command: [ cat ]
         tty: true
@@ -110,8 +112,9 @@ pipeline {
    */
   agent {
     kubernetes {
+      label _POD_LABEL
       yaml _POD_CONFIGURATION
-      defaultContainer 'main'
+      defaultContainer _STAGE_DEFAULT_CONTAINER
     }
   }
   /**

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -24,7 +24,7 @@
 /**
  * Pod configuration
  */
-final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_IMAGE = 'java17-base'
 final String _TSBI_VERSION = '3.1.9-20230228074507'
 
 /**

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -49,7 +49,7 @@ final String _POD_CONFIGURATION = """
   kind: Pod
   spec:
     containers:
-      - name: '${_TSBI_IMAGE}'
+      - name: main
         image: 'artifactory.datapwn.com/tlnd-docker-dev/talend/common/tsbi/${_TSBI_IMAGE}:${_TSBI_VERSION}'
         command: [ cat ]
         tty: true
@@ -111,7 +111,7 @@ pipeline {
   agent {
     kubernetes {
       yaml _POD_CONFIGURATION
-      defaultContainer _TSBI_IMAGE
+      defaultContainer 'main'
     }
   }
   /**

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -25,7 +25,7 @@
  * Pod configuration
  */
 final String _TSBI_IMAGE = 'jdk17-svc-builder'
-final String _TSBI_VERSION = '3.0.8-20220928070500'
+final String _TSBI_VERSION = '3.1.9-20230228074507'
 final String _STAGE_DEFAULT_CONTAINER = _TSBI_IMAGE
 final String _POD_LABEL = ((String) "tck-api-test-${UUID.randomUUID().toString()}").take(53)
 

--- a/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
+++ b/talend-component-maven-plugin/src/it/web/.jenkins/Jenkinsfile
@@ -24,8 +24,8 @@
 /**
  * Pod configuration
  */
-final String _TSBI_IMAGE = 'jdk11-svc-springboot-builder'
-final String _TSBI_VERSION = '2.9.18-2.4-20220104141654'
+final String _TSBI_IMAGE = 'jdk17-svc-builder'
+final String _TSBI_VERSION = '3.0.8-20220928070500'
 final String _STAGE_DEFAULT_CONTAINER = _TSBI_IMAGE
 final String _POD_LABEL = ((String) "tck-api-test-${UUID.randomUUID().toString()}").take(53)
 


### PR DESCRIPTION
### Requirements
https://jira.talendforge.org/browse/TCOMP-2367

### Why this PR is needed?
Jenkins job edition to move to custom builder tsbi base image
As explained in the doc https://github.com/Talend/tsbi-images/tree/main/tsbi/custom-builder, This image is intended to be the only image used on CI and should contain everything needed to build our products and run our automation scripts.

### What does this PR adds
- tools are now setups with asdf
- Pod config is now shared between build and scan` .jenkins/jenkins_pod.yml`
- rename veracode steps to uniformize with others projects