### PR TITLE
feat(TCOMP-2451): rework connector dependencies reference

### DIFF
--- a/component-api/src/main/java/org/talend/sdk/component/api/configuration/dependency/ConnectorRef.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/configuration/dependency/ConnectorRef.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2006-2023 Talend Inc. - www.talend.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.talend.sdk.component.api.configuration.dependency;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface ConnectorRef {
+
+    ConnectorRefValue value();
+
+    @RequiredArgsConstructor
+    enum ConnectorRefValue {
+
+        MAVEN_REFERENCE("mavenReference"),
+        NAME("name"),
+        FAMILY("family");
+
+        @Getter
+        private final String refValue;
+    }
+}

--- a/component-api/src/main/java/org/talend/sdk/component/api/configuration/dependency/ConnectorReference.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/configuration/dependency/ConnectorReference.java
@@ -18,9 +18,14 @@ package org.talend.sdk.component.api.configuration.dependency;
 import java.io.Serializable;
 
 import org.talend.sdk.component.api.configuration.Option;
+import org.talend.sdk.component.api.configuration.dependency.ConnectorRef.ConnectorRefValue;
 
 import lombok.Data;
 
+/**
+ * @deprecated since 1.58.0, use {@link ConnectorRef} instead
+ */
+@Deprecated
 @Data
 public class ConnectorReference implements Serializable {
 
@@ -28,18 +33,21 @@ public class ConnectorReference implements Serializable {
      * Family of referenced connector.
      */
     @Option
+    @ConnectorRef(ConnectorRefValue.FAMILY)
     private String family;
 
     /**
      * Name of referenced connector.
      */
     @Option
+    @ConnectorRef(ConnectorRefValue.NAME)
     private String name;
 
     /**
      * maven reference of referenced connector (as gav).
-     * exemple : org.talend.components:rest:1.29.0
+     * example : org.talend.components:rest:1.29.0
      */
     @Option
+    @ConnectorRef(ConnectorRefValue.MAVEN_REFERENCE)
     private String mavenReferences;
 }


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
https://jira.talendforge.org/browse/TCOMP-2451

### What does this PR adds (design/code thoughts)?
Deprecate ConnectorReference class, and introduce ConnectorRef annotation instead. It helps to use a custom structure when we want to add extra connector dependencies on a connector. It helps manage UI. 
