### PR TITLE
Revert "fix(TCOMP-2374): DIRecordVisitor to fill Studio Dynamic object's column name by tck Schema.Entry.getName which must follow tck name rule"

### DIFF
--- a/component-api/src/main/java/org/talend/sdk/component/api/record/SchemaProperty.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/record/SchemaProperty.java
@@ -33,6 +33,4 @@ public interface SchemaProperty {
 
     String IS_UNIQUE = "field.unique";
 
-    String ALLOW_SPECIAL_NAME = "field.special.name";
-
 }

--- a/component-studio/component-runtime-di/src/main/java/org/talend/sdk/component/runtime/di/record/DiRecordVisitor.java
+++ b/component-studio/component-runtime-di/src/main/java/org/talend/sdk/component/runtime/di/record/DiRecordVisitor.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Optional.ofNullable;
 import static java.util.function.UnaryOperator.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.talend.sdk.component.api.record.SchemaProperty.ALLOW_SPECIAL_NAME;
 import static org.talend.sdk.component.api.record.SchemaProperty.IS_KEY;
 import static org.talend.sdk.component.api.record.SchemaProperty.PATTERN;
 import static org.talend.sdk.component.api.record.SchemaProperty.SCALE;
@@ -132,8 +131,6 @@ public class DiRecordVisitor implements RecordVisitor<Object> {
         }
     }
 
-    private boolean allowSpecialName;
-
     public Object visit(final Record record) {
         arrayOfRecordPrefix = "";
         recordPrefix = "";
@@ -148,8 +145,6 @@ public class DiRecordVisitor implements RecordVisitor<Object> {
             dynamic.getDynamic().clearColumnValues();
         }
         if (hasDynamic && (recordFields == null)) {
-            allowSpecialName = Boolean.parseBoolean(record.getSchema().getProp(ALLOW_SPECIAL_NAME));
-
             recordFields =
                     record.getSchema().getAllEntries().filter(t -> t.getType().equals(Type.RECORD)).map(rcdEntry -> {
                         final String root = rcdEntry.getName() + ".";
@@ -218,19 +213,12 @@ public class DiRecordVisitor implements RecordVisitor<Object> {
 
     private DynamicMetadataWrapper generateMetadata(final Entry entry) {
         final DynamicMetadataWrapper metadata = new DynamicMetadataWrapper();
-        // now ALLOW_SPECIAL_NAME not conflict with the supported nested record as only jdbc connector use it and jdbc
-        // connector never support nested record
-        if (allowSpecialName) {
-            metadata.getDynamicMetadata()
-                    .setName(entry.getOriginalFieldName());
-        } else {
-            metadata.getDynamicMetadata()
-                    .setName(recordFields
-                            .stream()
-                            .filter(f -> f.endsWith("." + entry.getName()))
-                            .findFirst()
-                            .orElse(entry.getName()));
-        }
+        metadata.getDynamicMetadata()
+                .setName(recordFields
+                        .stream()
+                        .filter(f -> f.endsWith("." + entry.getName()))
+                        .findFirst()
+                        .orElse(entry.getName()));
         metadata.getDynamicMetadata().setDbName(entry.getOriginalFieldName());
         metadata.getDynamicMetadata().setNullable(entry.isNullable());
         metadata.getDynamicMetadata().setDescription(entry.getComment());
@@ -279,16 +267,11 @@ public class DiRecordVisitor implements RecordVisitor<Object> {
     private void setField(final Entry entry, final Object value) {
         final Field field = fields.get(entry.getName());
         if (hasDynamic && (field == null || dynamicColumn.equals(entry.getName()))) {
-            final String name;
-            if (allowSpecialName) {
-                name = entry.getOriginalFieldName();
-            } else {
-                name = recordFields
-                        .stream()
-                        .filter(f -> f.endsWith("." + entry.getName()))
-                        .findFirst()
-                        .orElse(entry.getName());
-            }
+            final String name = recordFields
+                    .stream()
+                    .filter(f -> f.endsWith("." + entry.getName()))
+                    .findFirst()
+                    .orElse(entry.getName());
             int index = dynamic.getDynamic().getIndex(name);
             final DynamicMetadataWrapper metadata;
             if (index < 0) {

--- a/component-studio/component-runtime-di/src/test/java/org/talend/sdk/component/runtime/di/record/DiRecordVisitorTest.java
+++ b/component-studio/component-runtime-di/src/test/java/org/talend/sdk/component/runtime/di/record/DiRecordVisitorTest.java
@@ -39,7 +39,6 @@ import org.talend.sdk.component.api.record.Schema;
 import org.talend.sdk.component.api.record.Schema.Type;
 import org.talend.sdk.component.api.record.SchemaProperty;
 import org.talend.sdk.component.runtime.di.schema.StudioTypes;
-import routines.system.Dynamic;
 
 class DiRecordVisitorTest extends VisitorsTest {
 
@@ -359,38 +358,6 @@ class DiRecordVisitorTest extends VisitorsTest {
         Assertions.assertEquals("valueMeta", row.meta1);
     }
 
-    @Test
-    void testSpecialNameForDynamic() {
-        final Schema.Entry entry = factory.newEntryBuilder().withName("the$name").withType(Type.STRING).build();
-        final Schema schemaAllSpecialName = factory.newSchemaBuilder(Type.RECORD)
-                .withEntry(entry)
-                .withProp(SchemaProperty.ALLOW_SPECIAL_NAME, "true")
-                .build();
-        final Record record1 = factory
-                .newRecordBuilder(schemaAllSpecialName)
-                .with(entry, "")
-                .build();
-        final DiRecordVisitor visitor1 = new DiRecordVisitor(RowStruct3.class, Collections.emptyMap());
-        final RowStruct3 rowStruct1 = RowStruct3.class.cast(visitor1.visit(record1));
-        assertNotNull(rowStruct1);
-        assertEquals("the$name", rowStruct1.dyn.getColumnMetadata(0).getName());
-        assertEquals("the$name", rowStruct1.dyn.getColumnMetadata(0).getDbName());
-
-        final Schema schemaNotAllSpecialName = factory.newSchemaBuilder(Type.RECORD)
-                .withEntry(entry)
-                .build();
-        final Record record2 = factory
-                .newRecordBuilder(schemaNotAllSpecialName)
-                .with(entry, "")
-                .build();
-        final DiRecordVisitor visitor2 = new DiRecordVisitor(RowStruct3.class, Collections.emptyMap());
-        final RowStruct3 rowStruct2 = RowStruct3.class.cast(visitor2.visit(record2));
-        assertNotNull(rowStruct2);
-        assertEquals("the_name", rowStruct2.dyn.getColumnMetadata(0).getName());
-        assertEquals("the$name", rowStruct2.dyn.getColumnMetadata(0).getDbName());
-
-    }
-
     public static class RowStruct2 implements routines.system.IPersistableRow {
 
         public String field1;
@@ -407,18 +374,4 @@ class DiRecordVisitorTest extends VisitorsTest {
         public void readData(ObjectInputStream objectInputStream) {
         }
     }
-
-    public static class RowStruct3 implements routines.system.IPersistableRow {
-
-        public Dynamic dyn;
-
-        @Override
-        public void writeData(ObjectOutputStream objectOutputStream) {
-        }
-
-        @Override
-        public void readData(ObjectInputStream objectInputStream) {
-        }
-    }
-
 }


### PR DESCRIPTION
Reverts Talend/component-runtime#787