### PR TITLE
fix(QTDI-1838): register ContainerFinder for studio

### DIFF
--- a/component-runtime-manager/src/main/resources/META-INF/services/org.talend.sdk.component.runtime.serialization.ContainerFinder
+++ b/component-runtime-manager/src/main/resources/META-INF/services/org.talend.sdk.component.runtime.serialization.ContainerFinder
@@ -1,0 +1,1 @@
+org.talend.sdk.component.runtime.manager.finder.StandaloneContainerFinder


### PR DESCRIPTION
* it was removed in 2020 and looks like we've missed it, it was added in a lot of modules for Cloud, but I think by mistake it was removed from component-runtime-manager.

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?
https://qlik-dev.atlassian.net/browse/QTDI-1838

### What does this PR adds (design/code thoughts)?
