### PR TITLE
chore(QTDI-1911): reduce doc versions

### DIFF
--- a/documentation/src/main/antora/site-template.yml
+++ b/documentation/src/main/antora/site-template.yml
@@ -180,7 +180,7 @@ content:
       - '!component-runtime-1.64.5'
       - '!component-runtime-1.64.6'
       - '!component-runtime-1.64.7'
-      - '!component-runtime-1.64.8'
+#      - '!component-runtime-1.64.8'
       - '!component-runtime-1.65.0'
       - '!component-runtime-1.*.0M*'
       - '!component-runtime-1.66.0'


### PR DESCRIPTION
* we don't need that amount of documentation versions
* keep latest released, snapshot, 0.0.12 as an old one, and 1.38.16 as used by 7.3

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
