### PR TITLE
fix(QTDI-1942): Support negative timestamp in MappingUtils#mapString.

### DIFF
--- a/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/record/MappingUtils.java
+++ b/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/record/MappingUtils.java
@@ -179,8 +179,9 @@ public class MappingUtils {
         if ("null".equalsIgnoreCase(value.trim())) {
             return null;
         }
-        //
-        final boolean isNumeric = value.chars().allMatch(Character::isDigit);
+
+        // A timestamp can be negative if before 1/1/1970, so need to consider '-' as first character.
+        boolean isNumeric = !value.isEmpty() && (value.charAt(0) == '-' ? value.substring(1) : value).chars().allMatch(Character::isDigit);
         if (ZonedDateTime.class == expected) {
             if (isNumeric) {
                 return ZonedDateTime.ofInstant(Instant.ofEpochMilli(Long.valueOf(value)), UTC);
@@ -191,7 +192,6 @@ public class MappingUtils {
         if (Date.class == expected) {
             if (isNumeric) {
                 return Date.from(Instant.ofEpochMilli(Long.valueOf(value)));
-
             } else {
                 return Date.from(ZonedDateTime.parse(value).toInstant());
             }


### PR DESCRIPTION
### Requirements
https://qlik-dev.atlassian.net/browse/QTDI-1942

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
