### PR TITLE
feat(QTDI-2023): Cherry-pick to 1.84: QTDI-1672 Allow disable nullable check in tck framework level …

### DIFF
--- a/component-api/src/main/java/org/talend/sdk/component/api/record/Record.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/record/Record.java
@@ -36,6 +36,8 @@ public interface Record {
 
     String RECORD_ERROR_SUPPORT = "talend.component.record.error.support";
 
+    String RECORD_NULLABLE_CHECK = "talend.component.record.nullable.check";
+
     /**
      * @return the schema of this record.
      */

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/RecordBuilderImplTest.java
@@ -233,6 +233,57 @@ class RecordBuilderImplTest {
     }
 
     @Test
+    void disableNullableCheck_no() {
+        RecordBuilderFactoryImpl recordBuilderFactory = new RecordBuilderFactoryImpl("test");
+        Schema.Builder schemaBuilder = recordBuilderFactory.newSchemaBuilder(Type.RECORD);
+        Schema schema = schemaBuilder.withEntry(
+                recordBuilderFactory.newEntryBuilder().withType(Type.STRING).withName("c1").withNullable(false).build())
+                .withEntry(recordBuilderFactory.newEntryBuilder()
+                        .withName("c2")
+                        .withType(Type.STRING)
+                        .withNullable(true)
+                        .build())
+                .build();
+        Record.Builder recordBuilder = recordBuilderFactory.newRecordBuilder(schema);
+        recordBuilder.withString("c1", "v1");
+        recordBuilder.build();
+
+        Schema.Builder schemaBuilder2 = recordBuilderFactory.newSchemaBuilder(Type.RECORD);
+        Schema schema2 = schemaBuilder2.withEntry(
+                recordBuilderFactory.newEntryBuilder().withType(Type.STRING).withName("c1").withNullable(false).build())
+                .withEntry(recordBuilderFactory.newEntryBuilder()
+                        .withName("c2")
+                        .withType(Type.STRING)
+                        .withNullable(false)
+                        .build())
+                .build();
+        Record.Builder recordBuilder2 = recordBuilderFactory.newRecordBuilder(schema2);
+        recordBuilder2.withString("c1", "v1");
+        assertThrows(IllegalArgumentException.class, recordBuilder2::build);
+    }
+
+    @Test
+    void disableNullableCheck_yes() {
+        System.setProperty(Record.RECORD_NULLABLE_CHECK, "true");
+        RecordBuilderFactoryImpl recordBuilderFactory = new RecordBuilderFactoryImpl("test");
+        Schema.Builder schemaBuilder = recordBuilderFactory.newSchemaBuilder(Type.RECORD);
+        Schema schema = schemaBuilder.withEntry(
+                recordBuilderFactory.newEntryBuilder().withType(Type.STRING).withName("c1").withNullable(false).build())
+                .withEntry(recordBuilderFactory.newEntryBuilder()
+                        .withName("c2")
+                        .withType(Type.STRING)
+                        .withNullable(false)
+                        .build())
+                .build();
+        Record.Builder recordBuilder = recordBuilderFactory.newRecordBuilder(schema);
+        recordBuilder.withString("c1", "v1");
+        recordBuilder.withString("c2", null);
+        Record recordOne = recordBuilder.build();
+        assertNull(recordOne.getString("c2"));
+        System.setProperty(Record.RECORD_NULLABLE_CHECK, "false");
+    }
+
+    @Test
     void dateTime() {
         final Schema schema = new SchemaImpl.BuilderImpl()
                 .withType(Schema.Type.RECORD)


### PR DESCRIPTION
…(#1086)

* feat(QTDI-1672): Allow disable nullable check in tck framework level

(cherry picked from commit 914dc7481236c09443faca4128fcb6a4a1528cf2)

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?
