### PR TITLE
chore(QTDI-2023): backport of QTDI-1813: upgrade tomcat to 9.0.108 (#1075)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <ziplock.test.version>8.0.14</ziplock.test.version>
     <meecrowave.version>1.2.15</meecrowave.version>
     <owb.version>2.0.27</owb.version>
-    <tomcat.version>9.0.104</tomcat.version>
+    <tomcat.version>9.0.108</tomcat.version>
     <cxf.version>3.5.10</cxf.version>
 
     <woodstox.version>6.5.0</woodstox.version>


### PR DESCRIPTION
(cherry picked from commit b892cceea7454caf7ce87a45012454b73645de09)

https://qlik-dev.atlassian.net/browse/QTDI-2023