### PR TITLE
chore(QTDI-2211): update bump tdi-jenkins-shared-libraries from 1.2.3 to 1.2.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ String deployOptions = "$skipOptions -Possrh -Prelease -Pgpg2 -Denforcer.skip=tr
 
 pipeline {
   libraries {
-    lib("connectors-lib@1.2.4") // https://github.com/Talend/tdi-jenkins-shared-libraries
+    lib("connectors-lib@1.2.5") // https://github.com/Talend/tdi-jenkins-shared-libraries
     lib("tqa-e2e-tests-tool@v2.4.2-ttp2")  // https://github.com/Talend/tqa-e2e-testing-tool
   }
   agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ String deployOptions = "$skipOptions -Possrh -Prelease -Pgpg2 -Denforcer.skip=tr
 
 pipeline {
   libraries {
-    lib("connectors-lib@1.2.3") // https://github.com/Talend/tdi-jenkins-shared-libraries
+    lib("connectors-lib@1.2.4") // https://github.com/Talend/tdi-jenkins-shared-libraries
     lib("tqa-e2e-tests-tool@v2.4.2-ttp2")  // https://github.com/Talend/tqa-e2e-testing-tool
   }
   agent {

--- a/ci/Jenkinsfile-trivy
+++ b/ci/Jenkinsfile-trivy
@@ -24,7 +24,7 @@ final String repository = 'component-runtime'
 
 pipeline {
   libraries {
-    lib("connectors-lib@1.2.4") // https://github.com/Talend/tdi-jenkins-shared-libraries
+    lib("connectors-lib@1.2.5") // https://github.com/Talend/tdi-jenkins-shared-libraries
     lib("tqa-e2e-tests-tool@v2.4.2-ttp2")  // https://github.com/Talend/tqa-e2e-testing-tool
   }
 

--- a/ci/Jenkinsfile-trivy
+++ b/ci/Jenkinsfile-trivy
@@ -24,7 +24,7 @@ final String repository = 'component-runtime'
 
 pipeline {
   libraries {
-    lib("connectors-lib@1.2.3") // https://github.com/Talend/tdi-jenkins-shared-libraries
+    lib("connectors-lib@1.2.4") // https://github.com/Talend/tdi-jenkins-shared-libraries
     lib("tqa-e2e-tests-tool@v2.4.2-ttp2")  // https://github.com/Talend/tqa-e2e-testing-tool
   }
 


### PR DESCRIPTION
chore(QTDI-2211): update bump tdi-jenkins-shared-libraries from 1.2.3 to 1.2.4

- search: lib("connectors-lib@1.2.3")
- replace: lib("connectors-lib@1.2.4")

Changed files:
- Jenkinsfile
- ci/Jenkinsfile-trivy

🤖 Automated PR
