### PR TITLE
feat(QTDI-2979): Add labelDisplayMode attribute to @Suggestable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,10 @@ documentation/rebuildpdf.bat
 .envrc
 .env
 *.versionsBackup
+
+# ai-commons knowledge base (managed by ai-commons/setup.sh)
+.ai-commons/
+.ai-commons/sessions/
+.ai-commons/skills/manage-zephyr-test-cases/references/.env
+.claude/CLAUDE.md
+.github/copilot-instructions.md

--- a/component-api/src/main/java/org/talend/sdk/component/api/configuration/action/Suggestable.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/configuration/action/Suggestable.java
@@ -74,4 +74,32 @@ public @interface Suggestable {
      * @return parameters for the validation.
      */
     String[] parameters() default { "." };
+
+    /**
+     * Controls how each suggestion option is rendered in the UI.
+     * Use {@link LabelDisplayMode#LABEL_ID} when option labels may not be unique,
+     * so that the identifier is shown alongside the label to allow unambiguous selection.
+     * Defaults to {@link LabelDisplayMode#LABEL} — preserves full backward compatibility.
+     *
+     * @return the display mode for suggestion options.
+     */
+    LabelDisplayMode labelDisplayMode() default LabelDisplayMode.LABEL;
+
+    /**
+     * Defines how suggestion options are displayed in the UI.
+     */
+    enum LabelDisplayMode {
+
+        /**
+         * Display the option label only.
+         * Default behaviour — use this when labels are unique.
+         */
+        LABEL,
+
+        /**
+         * Display both the label and the identifier, e.g. {@code Paris (fr-paris-01)}.
+         * Use this when labels may not be unique so that the user can make an unambiguous choice.
+         */
+        LABEL_ID
+    }
 }

--- a/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/reflect/Defaults.java
+++ b/component-runtime-impl/src/main/java/org/talend/sdk/component/runtime/reflect/Defaults.java
@@ -63,10 +63,11 @@ public class Defaults {
                     .invokeWithArguments(args);
         } else { // j > 8 - can need some --add-opens, we will add a module-info later to be clean when dropping j8
             final Method privateLookup = findPrivateLookup();
-            HANDLER = (clazz, method, proxy, args) -> ((MethodHandles.Lookup) privateLookup.invoke(null, clazz, constructor.newInstance(clazz)))
-                    .unreflectSpecial(method, clazz)
-                    .bindTo(proxy)
-                    .invokeWithArguments(args);
+            HANDLER = (clazz, method, proxy,
+                    args) -> ((MethodHandles.Lookup) privateLookup.invoke(null, clazz, constructor.newInstance(clazz)))
+                            .unreflectSpecial(method, clazz)
+                            .bindTo(proxy)
+                            .invokeWithArguments(args);
         }
     }
 

--- a/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/PluralRecordExtension.java
+++ b/component-runtime-impl/src/test/java/org/talend/sdk/component/runtime/record/PluralRecordExtension.java
@@ -58,7 +58,7 @@ public class PluralRecordExtension implements ParameterResolver, AfterEachCallba
         // create a Jsonb instance which is PojoJsonbProvider as in component-runtime-manager
         return (Jsonb) Proxy
                 .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-                        new Class<?>[]{Jsonb.class, PojoJsonbProvider.class}, (proxy, method, args) -> {
+                        new Class<?>[] { Jsonb.class, PojoJsonbProvider.class }, (proxy, method, args) -> {
                             if (method.getDeclaringClass() == Supplier.class) {
                                 return jsonb;
                             }

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/ComponentManager.java
@@ -1924,7 +1924,8 @@ public class ComponentManager implements AutoCloseable {
                     () -> {
                         final List<ParameterMeta> params = parameterModelService
                                 .buildParameterMetas(constructor, getPackage(type),
-                                        new BaseParameterEnricher.Context((LocalConfiguration) services.getServices().get(LocalConfiguration.class)));
+                                        new BaseParameterEnricher.Context((LocalConfiguration) services.getServices()
+                                                .get(LocalConfiguration.class)));
                         if (infinite) {
                             if (partitionMapper.stoppable()) {
                                 addInfiniteMapperBuiltInParameters(type, params);
@@ -1977,7 +1978,8 @@ public class ComponentManager implements AutoCloseable {
             final Supplier<List<ParameterMeta>> parameterMetas = lazy(() -> executeInContainer(plugin,
                     () -> parameterModelService
                             .buildParameterMetas(constructor, getPackage(type),
-                                    new BaseParameterEnricher.Context((LocalConfiguration) services.getServices().get(LocalConfiguration.class)))));
+                                    new BaseParameterEnricher.Context((LocalConfiguration) services.getServices()
+                                            .get(LocalConfiguration.class)))));
             final Function<Map<String, String>, Object[]> parameterFactory =
                     createParametersFactory(plugin, constructor, services.getServices(), parameterMetas);
             final String name = of(emitter.name()).filter(n -> !n.isEmpty()).orElseGet(type::getName);
@@ -2161,7 +2163,8 @@ public class ComponentManager implements AutoCloseable {
             final Supplier<List<ParameterMeta>> parameterMetas = lazy(() -> executeInContainer(plugin,
                     () -> parameterModelService
                             .buildParameterMetas(constructor, getPackage(type),
-                                    new BaseParameterEnricher.Context((LocalConfiguration) services.getServices().get(LocalConfiguration.class)))));
+                                    new BaseParameterEnricher.Context((LocalConfiguration) services.getServices()
+                                            .get(LocalConfiguration.class)))));
             final Function<Map<String, String>, Object[]> parameterFactory =
                     createParametersFactory(plugin, constructor, services.getServices(), parameterMetas);
             final String name = of(processor.name()).filter(n -> !n.isEmpty()).orElseGet(type::getName);

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/reflect/ParameterModelService.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/reflect/ParameterModelService.java
@@ -254,10 +254,10 @@ public class ParameterModelService {
                 .concat(Stream.of(annotations),
                         // if a class concat its annotations
                         genericType instanceof Class
-                                        ? getClassAnnotations(genericType, annotations)
-                                        : (hasAClassFirstParameter(genericType) ? getClassAnnotations(
-                                                ((ParameterizedType) genericType).getActualTypeArguments()[0],
-                                                annotations) : Stream.empty()));
+                                ? getClassAnnotations(genericType, annotations)
+                                : (hasAClassFirstParameter(genericType) ? getClassAnnotations(
+                                        ((ParameterizedType) genericType).getActualTypeArguments()[0],
+                                        annotations) : Stream.empty()));
     }
 
     private boolean hasAClassFirstParameter(final Type genericType) {
@@ -297,7 +297,7 @@ public class ParameterModelService {
                 }
                 return Stream
                         .concat(buildParametersMetas(name + ".key[${index}]", prefix + "key[${index}].",
-                                        (Class) pt.getActualTypeArguments()[0], annotations, i18nPackages, ignoreI18n,
+                                (Class) pt.getActualTypeArguments()[0], annotations, i18nPackages, ignoreI18n,
                                 context).stream(),
                                 buildParametersMetas(name + ".value[${index}]", prefix + "value[${index}].",
                                         (Class) pt.getActualTypeArguments()[1], annotations, i18nPackages,

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/reflect/ReflectionService.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/reflect/ReflectionService.java
@@ -524,10 +524,11 @@ public class ReflectionService {
                 if (arrayClass.isArray()) {
                     // we could use Array.newInstance but for now use the list, shouldn't impact
                     // much the perf
-                    final Collection<?> list = (Collection) createList(loader, contextualSupplier, prefix + enclosingName, List.class,
-                            arrayClass.getComponentType(), toList(), createObjectFactory(loader,
-                                    contextualSupplier, arrayClass.getComponentType(), metas, precomputed),
-                            new HashMap<>(listEntries), metas, precomputed);
+                    final Collection<?> list =
+                            (Collection) createList(loader, contextualSupplier, prefix + enclosingName, List.class,
+                                    arrayClass.getComponentType(), toList(), createObjectFactory(loader,
+                                            contextualSupplier, arrayClass.getComponentType(), metas, precomputed),
+                                    new HashMap<>(listEntries), metas, precomputed);
 
                     // we need that conversion to ensure the type matches
                     final Object array = Array.newInstance(arrayClass.getComponentType(), list.size());

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/service/InjectorImpl.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/service/InjectorImpl.java
@@ -128,7 +128,8 @@ public class InjectorImpl implements Serializable, Injector {
                 })
                 .forEach(field -> {
                     try {
-                        final Class<?> configClass = (Class) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+                        final Class<?> configClass =
+                                (Class) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
                         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
                         final Supplier<?> supplier = () -> {
                             try {

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ComponentManagerTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ComponentManagerTest.java
@@ -611,7 +611,8 @@ class ComponentManagerTest {
             manager.addPlugin(plugin.getAbsolutePath());
             final Container container = manager.getContainer().findAll().stream().findFirst().orElse(null);
             assertNotNull(container);
-            final LocalConfiguration envConf = (LocalConfiguration) container.get(AllServices.class).getServices().get(LocalConfiguration.class);
+            final LocalConfiguration envConf =
+                    (LocalConfiguration) container.get(AllServices.class).getServices().get(LocalConfiguration.class);
             // check translated env vars
             assertEquals("/home/user", envConf.get("USER_PATH"));
             assertEquals("/home/user", envConf.get("USER.PATH"));

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ConfigurationMigrationTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ConfigurationMigrationTest.java
@@ -42,12 +42,14 @@ class ConfigurationMigrationTest {
                 "META-INF/test/dependencies", "org.talend.test:type=plugin,value=%s")) {
             manager.addPlugin(jar.getAbsolutePath());
             {
-                final Object nested = ((ProcessorImpl) manager.findProcessor("chain", "configured1", 0, new HashMap<String, String>() {
+                final Object nested = ((ProcessorImpl) manager
+                        .findProcessor("chain", "configured1", 0, new HashMap<String, String>() {
 
-                    {
-                        put("config.__version", "-1");
-                    }
-                }).orElseThrow(IllegalStateException::new))
+                            {
+                                put("config.__version", "-1");
+                            }
+                        })
+                        .orElseThrow(IllegalStateException::new))
                         .getDelegate();
 
                 final Object config = get(nested, "getConfig");
@@ -55,13 +57,15 @@ class ConfigurationMigrationTest {
                 assertEquals("ok", get(config, "getName"));
             }
             {
-                final Object nested = ((ProcessorImpl) manager.findProcessor("chain", "configured2", 0, new HashMap<String, String>() {
+                final Object nested = ((ProcessorImpl) manager
+                        .findProcessor("chain", "configured2", 0, new HashMap<String, String>() {
 
-                    {
-                        put("config.__version", "0");
-                        put("value.__version", "-1");
-                    }
-                }).orElseThrow(IllegalStateException::new))
+                            {
+                                put("config.__version", "0");
+                                put("value.__version", "-1");
+                            }
+                        })
+                        .orElseThrow(IllegalStateException::new))
                         .getDelegate();
                 assertEquals("set", get(nested, "getValue"));
 
@@ -70,13 +74,15 @@ class ConfigurationMigrationTest {
                 assertEquals("ok", get(config, "getName"));
             }
             {
-                final Object nested = ((ProcessorImpl) manager.findProcessor("chain", "migrationtest", -1, new HashMap<String, String>() {
+                final Object nested = ((ProcessorImpl) manager
+                        .findProcessor("chain", "migrationtest", -1, new HashMap<String, String>() {
 
-                    {
-                        put("config.__version", "1");
-                        put("config.datastore.__version", "1");
-                    }
-                }).orElseThrow(IllegalStateException::new))
+                            {
+                                put("config.__version", "1");
+                                put("config.datastore.__version", "1");
+                            }
+                        })
+                        .orElseThrow(IllegalStateException::new))
                         .getDelegate();
 
                 final Object config = get(nested, "getConfig");

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ReflectionServiceTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/ReflectionServiceTest.java
@@ -450,8 +450,10 @@ class ReflectionServiceTest {
                         new HttpClientFactoryImpl("test", reflectionService, JsonbBuilder.create(), emptyMap())
                                 .create(UserHttpClient.class, "http://foo"));
         final Method httpMtd = TableOwner.class.getMethod("http", UserHttpClient.class);
-        final HttpClient client1 = (HttpClient) reflectionService.parameterFactory(httpMtd, precomputed, null).apply(emptyMap())[0];
-        final HttpClient client2 = (HttpClient) reflectionService.parameterFactory(httpMtd, precomputed, null).apply(emptyMap())[0];
+        final HttpClient client1 =
+                (HttpClient) reflectionService.parameterFactory(httpMtd, precomputed, null).apply(emptyMap())[0];
+        final HttpClient client2 =
+                (HttpClient) reflectionService.parameterFactory(httpMtd, precomputed, null).apply(emptyMap())[0];
         assertNotSame(client1, client2);
         final InvocationHandler handler1 = Proxy.getInvocationHandler(client1);
         final InvocationHandler handler2 = Proxy.getInvocationHandler(client2);

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/reflect/parameterenricher/ActionParameterEnricherTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/reflect/parameterenricher/ActionParameterEnricherTest.java
@@ -219,6 +219,14 @@ class ActionParameterEnricherTest {
     }
 
     @Test
+    void suggestable_labelDisplayMode_defaultsToLabel() throws Exception {
+        Suggestable.LabelDisplayMode defaultMode = (Suggestable.LabelDisplayMode) Suggestable.class
+                .getDeclaredMethod("labelDisplayMode")
+                .getDefaultValue();
+        assertEquals(Suggestable.LabelDisplayMode.LABEL, defaultMode);
+    }
+
+    @Test
     void condition() {
         assertEquals(new HashMap<String, String>() {
 

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/reflect/parameterenricher/ActionParameterEnricherTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/reflect/parameterenricher/ActionParameterEnricherTest.java
@@ -159,6 +159,7 @@ class ActionParameterEnricherTest {
             {
                 put("tcomp::action::suggestions", "test");
                 put("tcomp::action::suggestions::parameters", ".,foo,/bar/dummy");
+                put("tcomp::action::suggestions::labelDisplayMode", "LABEL");
             }
         }, new ActionParameterEnricher().onParameterAnnotation("testParam", String.class, new Suggestable() {
 
@@ -170,6 +171,44 @@ class ActionParameterEnricherTest {
             @Override
             public String[] parameters() {
                 return new String[] { ".", "foo", "/bar/dummy" };
+            }
+
+            @Override
+            public LabelDisplayMode labelDisplayMode() {
+                return LabelDisplayMode.LABEL;
+            }
+
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return Suggestable.class;
+            }
+        }));
+    }
+
+    @Test
+    void suggestionWithLabelId() {
+        assertEquals(new HashMap<String, String>() {
+
+            {
+                put("tcomp::action::suggestions", "test");
+                put("tcomp::action::suggestions::parameters", ".");
+                put("tcomp::action::suggestions::labelDisplayMode", "LABEL_ID");
+            }
+        }, new ActionParameterEnricher().onParameterAnnotation("testParam", String.class, new Suggestable() {
+
+            @Override
+            public String value() {
+                return "test";
+            }
+
+            @Override
+            public String[] parameters() {
+                return new String[] { "." };
+            }
+
+            @Override
+            public LabelDisplayMode labelDisplayMode() {
+                return LabelDisplayMode.LABEL_ID;
             }
 
             @Override

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/service/RecordServiceImplTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/service/RecordServiceImplTest.java
@@ -52,7 +52,8 @@ class RecordServiceImplTest {
 
     private final RecordBuilderFactory factory = new RecordBuilderFactoryImpl(null);
 
-    private final RecordService service = (RecordService) new DefaultServiceProvider(null, JsonProvider.provider(), Json.createGeneratorFactory(emptyMap()),
+    private final RecordService service = (RecordService) new DefaultServiceProvider(null, JsonProvider.provider(),
+            Json.createGeneratorFactory(emptyMap()),
             Json.createReaderFactory(emptyMap()), Json.createBuilderFactory(emptyMap()),
             Json.createParserFactory(emptyMap()), Json.createWriterFactory(emptyMap()), new JsonbConfig(),
             JsonbProvider.provider(), null, null, emptyList(), t -> factory, null)
@@ -104,28 +105,28 @@ class RecordServiceImplTest {
         assertEquals(3,
                 service
                         .visit((RecordVisitor) Proxy
-                                        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-                                                new Class<?>[]{RecordVisitor.class}, (proxy, method, args) -> {
-                                                    visited
-                                                            .add(method.getName() + "/"
-                                                                    + (args == null ? "null"
+                                .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+                                        new Class<?>[] { RecordVisitor.class }, (proxy, method, args) -> {
+                                            visited
+                                                    .add(method.getName() + "/"
+                                                            + (args == null ? "null"
                                                                     : Stream
-                                                                    .of(args)
-                                                                    .filter(it -> !(it instanceof Schema.Entry))
-                                                                    .collect(Collectors.toList())));
-                                                    switch (method.getName()) {
-                                                        case "get":
-                                                            return out.incrementAndGet();
-                                                        case "apply":
-                                                            return asList(args)
-                                                                    .stream()
-                                                                    .mapToInt(Integer.class::cast)
-                                                                    .sum();
-                                                        default:
-                                                            return method.getReturnType() == RecordVisitor.class ? proxy
-                                                                    : null;
-                                                    }
-                                                }),
+                                                                            .of(args)
+                                                                            .filter(it -> !(it instanceof Schema.Entry))
+                                                                            .collect(Collectors.toList())));
+                                            switch (method.getName()) {
+                                                case "get":
+                                                    return out.incrementAndGet();
+                                                case "apply":
+                                                    return asList(args)
+                                                            .stream()
+                                                            .mapToInt(Integer.class::cast)
+                                                            .sum();
+                                                default:
+                                                    return method.getReturnType() == RecordVisitor.class ? proxy
+                                                            : null;
+                                            }
+                                        }),
                                 baseRecord));
         assertEquals(asList("onString/[Optional[Test]]", "onInt/[OptionalInt[33]]",
                 "onRecord/[Optional[{\"street\":\"here\",\"number\":1}]]", "onString/[Optional[here]]",

--- a/component-runtime-testing/component-runtime-junit/src/main/java/org/talend/sdk/component/junit5/ComponentExtension.java
+++ b/component-runtime-testing/component-runtime-junit/src/main/java/org/talend/sdk/component/junit5/ComponentExtension.java
@@ -112,7 +112,8 @@ public class ComponentExtension extends BaseComponentsHandler
     }
 
     public void doStop(final ExtensionContext extensionContext) {
-        ofNullable((EmbeddedComponentManager) extensionContext.getStore(NAMESPACE).get(EmbeddedComponentManager.class.getName()))
+        ofNullable((EmbeddedComponentManager) extensionContext.getStore(NAMESPACE)
+                .get(EmbeddedComponentManager.class.getName()))
                 .ifPresent(EmbeddedComponentManager::close);
     }
 

--- a/component-tools/src/test/java/org/talend/sdk/component/tools/ComponentValidatorTest.java
+++ b/component-tools/src/test/java/org/talend/sdk/component/tools/ComponentValidatorTest.java
@@ -182,8 +182,9 @@ class ComponentValidatorTest {
         public void afterEach(final ExtensionContext context) {
             final ExtensionContext.Store store = context.getStore(NAMESPACE);
             final boolean fails = !((ComponentPackage) store.get(ComponentPackage.class.getName())).success();
-            final String expectedMessage = ((ExceptionSpec) context.getStore(NAMESPACE).get(ExceptionSpec.class.getName()))
-                    .getMessage();
+            final String expectedMessage =
+                    ((ExceptionSpec) context.getStore(NAMESPACE).get(ExceptionSpec.class.getName()))
+                            .getMessage();
             try {
                 ((ComponentValidator) store.get(ComponentValidator.class.getName())).run();
                 if (fails) {

--- a/documentation/src/main/java/org/talend/runtime/documentation/Generator.java
+++ b/documentation/src/main/java/org/talend/runtime/documentation/Generator.java
@@ -373,7 +373,8 @@ public class Generator {
             stream.println("Therefore, the following packages are ignored:");
             stream.println();
             stream.println("[.talend-filterlist]");
-            ((KnownClassesFilter.OptimizedExclusionFilter) ((KnownClassesFilter) KnownClassesFilter.INSTANCE).getDelegateSkip())
+            ((KnownClassesFilter.OptimizedExclusionFilter) ((KnownClassesFilter) KnownClassesFilter.INSTANCE)
+                    .getDelegateSkip())
                     .getIncluded()
                     .stream()
                     .sorted()

--- a/singer-parent/component-kitap/src/main/java/org/talend/sdk/component/singer/kitap/RecordJsonMapper.java
+++ b/singer-parent/component-kitap/src/main/java/org/talend/sdk/component/singer/kitap/RecordJsonMapper.java
@@ -58,7 +58,8 @@ public class RecordJsonMapper implements Function<Record, JsonObject> {
 
     private final Singer singer;
 
-    private final RecordService service = (RecordService) new DefaultServiceProvider(null, JsonProvider.provider(), Json.createGeneratorFactory(emptyMap()),
+    private final RecordService service = (RecordService) new DefaultServiceProvider(null, JsonProvider.provider(),
+            Json.createGeneratorFactory(emptyMap()),
             Json.createReaderFactory(emptyMap()), Json.createBuilderFactory(emptyMap()),
             Json.createParserFactory(emptyMap()), Json.createWriterFactory(emptyMap()), new JsonbConfig(),
             JsonbProvider.provider(), null, null, emptyList(), t -> new RecordBuilderFactoryImpl("kitap"), null)


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant

### Why this PR is needed?

Jira: [QTDI-2979](https://jira.talendforge.org/browse/QTDI-2979) — _Allow to configure how the labels are displayed for a suggestable field_

When two or more `@Suggestable` options share the same label, the Studio user cannot distinguish between them. Selecting the wrong option leads to misconfigured jobs that may only fail at runtime, which is costly to debug.

This PR provides a TCK-level mechanism that allows component developers to declare that their suggestable field may have non-unique labels, so that the front-end can surface enough information for an unambiguous choice.

### What does this PR adds (design/code thoughts)?

**`component-api` — `Suggestable.java`**

- Adds an inner enum `LabelDisplayMode` with two constants:
  - `LABEL` (default) — show option label only; no change for existing usages.
  - `LABEL_ID` — show both label and identifier (e.g. `Paris (fr-paris-01)`); use when labels may not be unique.
- Adds annotation attribute `labelDisplayMode()` defaulting to `LabelDisplayMode.LABEL`.

**Serialisation (no change to `ActionParameterEnricher`)**

The existing `ActionParameterEnricher` already serialises all annotation methods generically. The new attribute appears automatically in the component metadata map as:

```
tcomp::action::suggestions::labelDisplayMode = "LABEL"   // or "LABEL_ID"
```

No changes to `component-server-model` are required — `SimplePropertyDefinition.metadata` is already a `Map<String, String>`.

**Tests — `ActionParameterEnricherTest.java`**

- Updated `suggestion()` test: asserts that the default value produces `labelDisplayMode = "LABEL"` in the serialised metadata.
- New `suggestionWithLabelId()` test: asserts that setting `labelDisplayMode = LABEL_ID` produces `labelDisplayMode = "LABEL_ID"`.

**Backward compatibility**

The attribute defaults to `LABEL`. All existing `@Suggestable` usages gain `labelDisplayMode = LABEL` in their metadata map — additive, transparent to consumers that do not know the key.

**Out of scope**

- Studio rendering (separate future ticket)
- `BuiltInSuggestable` — not affected
- Documentation ticket (PO to open)

### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool

[QTDI-2979]: https://qlik-dev.atlassian.net/browse/QTDI-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ