### PR TITLE
fix(QTDI-3123): Also deploy SNAPSHOTs to internal Nexus on master builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -466,6 +466,23 @@ pipeline {
               """.stripIndent()
           }
         }
+        // Also deploy to internal Nexus on master/maintenance builds so that
+        // connector-se Jenkins agents (which cannot reach central.sonatype.com)
+        // can resolve SNAPSHOT dependencies.
+        script {
+          if (stdBranch_buildOnly) {
+            String nexusDeployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
+            withCredentials([nexusCredentials]) {
+              sh """\
+                #!/usr/bin/env bash
+                set -xe
+                mvn deploy ${nexusDeployOptions} \
+                            ${extraBuildParams} \
+                            --settings .jenkins/settings.xml
+                """.stripIndent()
+            }
+          }
+        }
         // Add description to job
         script {
           def repo
@@ -478,6 +495,9 @@ pipeline {
           }
 
           JenkinsStatusController.jobDescriptionAppend("Maven artefact deployed as ${finalVersion} on [${repo[0]}](${repo[1]})  ")
+          if (stdBranch_buildOnly) {
+            JenkinsStatusController.jobDescriptionAppend("Maven artefact also deployed as ${finalVersion} on [artifacts-zl.talend.com](https://artifacts-zl.talend.com/nexus/content/repositories/snapshots/org/talend/sdk/component)  ")
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,7 +471,7 @@ pipeline {
         // can resolve SNAPSHOT dependencies.
         script {
           if (stdBranch_buildOnly) {
-            String nexusDeployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
+            def nexusDeployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
             withCredentials([nexusCredentials]) {
               sh """\
                 #!/usr/bin/env bash

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ Boolean devBranch_dockerPush = false
 
 String skipOptions = "-Dspotless.apply.skip=true -Dcheckstyle.skip=true -Drat.skip=true -DskipTests -Dinvoker.skip=true"
 String deployOptions = "$skipOptions -Possrh -Prelease -Pgpg2 -Denforcer.skip=true"
+String nexusDeployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
 
 
 pipeline {
@@ -283,7 +284,7 @@ pipeline {
           if (needQualify) {
             // Qualified version have to be released on talend_repository
             // Overwrite the deployOptions
-            deployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
+            deployOptions = nexusDeployOptions
           }
 
           // hack to overwrite the skip of studio modules that we can't deploy in release mode into Sonatype repo
@@ -467,11 +468,10 @@ pipeline {
           }
         }
         // Also deploy to internal Nexus on master/maintenance builds so that
-        // connector-se Jenkins agents (which cannot reach central.sonatype.com)
+        // connectors-se Jenkins agents (which cannot reach central.sonatype.com)
         // can resolve SNAPSHOT dependencies.
         script {
           if (stdBranch_buildOnly) {
-            def nexusDeployOptions = "$skipOptions --activate-profiles private_repository -Denforcer.skip=true"
             withCredentials([nexusCredentials]) {
               sh """\
                 #!/usr/bin/env bash
@@ -486,9 +486,9 @@ pipeline {
         // Add description to job
         script {
           def repo
+          String nexusSnapshotUrl = 'https://artifacts-zl.talend.com/nexus/content/repositories/snapshots/org/talend/sdk/component'
           if (devBranch_mavenDeploy) {
-            repo = ['artifacts-zl.talend.com',
-                    'https://artifacts-zl.talend.com/nexus/content/repositories/snapshots/org/talend/sdk/component']
+            repo = ['artifacts-zl.talend.com', nexusSnapshotUrl]
           } else {
             repo = ['oss.sonatype.org',
                     'https://central.sonatype.com/repository/maven-snapshots/org/talend/sdk/component/']
@@ -496,7 +496,7 @@ pipeline {
 
           JenkinsStatusController.jobDescriptionAppend("Maven artefact deployed as ${finalVersion} on [${repo[0]}](${repo[1]})  ")
           if (stdBranch_buildOnly) {
-            JenkinsStatusController.jobDescriptionAppend("Maven artefact also deployed as ${finalVersion} on [artifacts-zl.talend.com](https://artifacts-zl.talend.com/nexus/content/repositories/snapshots/org/talend/sdk/component)  ")
+            JenkinsStatusController.jobDescriptionAppend("Maven artefact also deployed as ${finalVersion} on [artifacts-zl.talend.com](${nexusSnapshotUrl})  ")
           }
         }
       }


### PR DESCRIPTION
### Requirements
* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant
### Why this PR is needed?
PR #1515 (QTDI-1369) bumped `component-runtime.version` from `1.93.0` → `1.94.0-SNAPSHOT` in `connectors-se`. This caused persistent Jenkins build failures: the `connectors-se` Jenkins agents cannot reach `central.sonatype.com` (network blocked), and `component-runtime` master builds were deploying SNAPSHOTs **only** to `central.sonatype.com` — not to the internal Nexus (`artifacts-zl.talend.com`). Maven caches the resolution failure, causing all subsequent builds to fail.
Jira ticket: [QTDI-3123](https://qlik-dev.atlassian.net/browse/QTDI-3123)
### What does this PR adds (design/code thoughts)?
In the `Maven deploy` stage of `Jenkinsfile`, adds a second `mvn deploy` call guarded by `if (stdBranch_buildOnly)` (master/maintenance builds only). The call activates `-Pprivate_repository` to also publish SNAPSHOTs to `artifacts-zl.talend.com/nexus/content/repositories/snapshots` using `nexusCredentials` (no GPG signing needed for internal Nexus).
**Why two separate Maven invocations?** Activating both `-Possrh -Psnapshot` and `-Pprivate_repository` in a single call would deploy only to Nexus because `private_repository` overrides `snapshotRepository`. Two separate calls are the only correct way to publish to both endpoints.
**Compliance notes** (committed history — not rewritten):
- ⚠️ Commit subjects slightly exceed the 50-char recommendation (55 and 52 chars)
- ℹ️ Pre-existing `bash mvn deploy` typo in the first deploy call is out of scope per approved plan
### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool

[QTDI-3123]: https://qlik-dev.atlassian.net/browse/QTDI-3123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ