### PR TITLE
feat(QTDI-2862): Add watch() attribute to @FixedSchema

### DIFF
--- a/component-api/src/main/java/org/talend/sdk/component/api/service/schema/FixedSchema.java
+++ b/component-api/src/main/java/org/talend/sdk/component/api/service/schema/FixedSchema.java
@@ -42,4 +42,13 @@ public @interface FixedSchema {
      */
     String[] flows() default {};
 
+    /**
+     * Parameter paths that trigger a schema refresh in Studio when their value changes.
+     * Uses the same dot-notation as {@code @Updatable#parameters()}, relative to the component root.
+     * Example: {@code watch = {"configuration.dataSet.connection.url"}}
+     *
+     * @return the parameter paths to watch. Default to none (no dynamic refresh).
+     */
+    String[] watch() default {};
+
 }

--- a/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/extension/ComponentSchemaEnricher.java
+++ b/component-runtime-manager/src/main/java/org/talend/sdk/component/runtime/manager/extension/ComponentSchemaEnricher.java
@@ -46,6 +46,8 @@ public class ComponentSchemaEnricher implements ComponentMetadataEnricher {
 
     public static final String FIXED_SCHEMA_FLOWS_META_PREFIX = "tcomp::ui::schema::flows::fixed";
 
+    public static final String FIXED_SCHEMA_WATCH_META_PREFIX = "tcomp::ui::schema::fixed::watch";
+
     private static final Set<Class<? extends Annotation>> SUPPORTED_ANNOTATIONS =
             new HashSet<>(Arrays.asList(PartitionMapper.class, Emitter.class, Processor.class, DriverRunner.class));
 
@@ -83,6 +85,9 @@ public class ComponentSchemaEnricher implements ComponentMetadataEnricher {
             metadata.put(FIXED_SCHEMA_FLOWS_META_PREFIX, String.join(",", fixedSchema.flows()));
         } else {
             metadata.put(FIXED_SCHEMA_FLOWS_META_PREFIX, Branches.DEFAULT_BRANCH);
+        }
+        if (fixedSchema.watch().length > 0) {
+            metadata.put(FIXED_SCHEMA_WATCH_META_PREFIX, String.join(",", fixedSchema.watch()));
         }
 
         return metadata;

--- a/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/extension/ComponentSchemaEnricherTest.java
+++ b/component-runtime-manager/src/test/java/org/talend/sdk/component/runtime/manager/extension/ComponentSchemaEnricherTest.java
@@ -61,6 +61,38 @@ class ComponentSchemaEnricherTest {
     }
 
     @Test
+    void fixedSchemaWatchSinglePath() {
+        assertEquals(new HashMap<String, String>() {
+
+            {
+                put("tcomp::ui::schema::fixed", "discover");
+                put("tcomp::ui::schema::flows::fixed", "__default__");
+                put("tcomp::ui::schema::fixed::watch", "configuration.dataSet.connection.url");
+            }
+        }, enricher.onComponent(EmitterWithWatch.class, EmitterWithWatch.class.getAnnotations()));
+    }
+
+    @Test
+    void fixedSchemaWatchMultiplePaths() {
+        assertEquals(new HashMap<String, String>() {
+
+            {
+                put("tcomp::ui::schema::fixed", "discover");
+                put("tcomp::ui::schema::flows::fixed", "__default__");
+                put("tcomp::ui::schema::fixed::watch", "configuration.dataSet.url,configuration.dataSet.table");
+            }
+        }, enricher.onComponent(EmitterWithMultiWatch.class, EmitterWithMultiWatch.class.getAnnotations()));
+    }
+
+    @Test
+    void fixedSchemaWatchEmptyDoesNotEmitKey() {
+        final java.util.Map<String, String> result =
+                enricher.onComponent(MyEmitter.class, MyEmitter.class.getAnnotations());
+        org.junit.jupiter.api.Assertions.assertFalse(result.containsKey("tcomp::ui::schema::fixed::watch"),
+                "watch key must be absent when watch() is empty");
+    }
+
+    @Test
     void dbMappingMetadataPresent() {
         assertEquals(new HashMap<String, String>() {
 
@@ -101,6 +133,18 @@ class ComponentSchemaEnricherTest {
     @Emitter
     @FixedSchema(value = "discover")
     private static class MyEmitter {
+
+    }
+
+    @Emitter
+    @FixedSchema(value = "discover", watch = { "configuration.dataSet.connection.url" })
+    private static class EmitterWithWatch {
+
+    }
+
+    @Emitter
+    @FixedSchema(value = "discover", watch = { "configuration.dataSet.url", "configuration.dataSet.table" })
+    private static class EmitterWithMultiWatch {
 
     }
 }

--- a/documentation/src/main/antora/modules/ROOT/pages/studio-schema.adoc
+++ b/documentation/src/main/antora/modules/ROOT/pages/studio-schema.adoc
@@ -268,6 +268,16 @@ In some cases, the schema will always use the same scheme.
 Having a fixed schema will prevent Studio to display the Guess schema button and the reject UI part.
 The annotation's value should point to a `@DiscoverSchema` or `@DiscoverSchemaExtended` action.
 
+The `@FixedSchema` annotation accepts the following attributes:
+
+[cols="1,1,3",options="header"]
+|===
+| Attribute | Default | Description
+| `value` | `""` | Name of the `@DiscoverSchema` / `@DiscoverSchemaExtended` action that returns the fixed schema.
+| `flows` | `{}` (main flow) | The connector flows to which the fixed schema applies. For Input components this is always the main flow. For Output components you can list `main`, `reject`, or any custom flow name. Studio's main flow key is `__default__`.
+| `watch` | `{}` (none) | Parameter paths (dot-notation, relative to the component root) whose value change triggers an automatic schema refresh in Studio. Uses the same path syntax as `@Updatable#parameters()`. Example: `watch = {"configuration.dataSet.connection.url"}`.
+|===
+
 Example with an emitter:
 
 [source,java]


### PR DESCRIPTION
### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

[QTDI-2862](https://qlik-dev.atlassian.net/browse/QTDI-2862) — The `@FixedSchema` annotation currently offers no way to tell Studio which configuration parameters should trigger an automatic schema refresh. Without this, Studio cannot know when the fixed schema may have changed (e.g. when the user selects a different dataset or changes a connection URL), and the schema is never refreshed dynamically.

### What does this PR add (design/code thoughts)?

Adds a new optional `watch()` attribute to `@FixedSchema` accepting parameter path strings in the same dot-notation as `@Updatable#parameters()`.

- **`component-api` — `FixedSchema.java`**: new `String[] watch() default {}` attribute with Javadoc.
- **`component-runtime-manager` — `ComponentSchemaEnricher.java`**: new constant `FIXED_SCHEMA_WATCH_META_PREFIX = "tcomp::ui::schema::fixed::watch"`. When `watch()` is non-empty, the enricher emits the comma-joined paths under this key. When empty (default), the key is not emitted — full backward compatibility.
- **`ComponentSchemaEnricherTest.java`**: 3 new unit tests covering single path, multiple paths (comma-joined), and empty `watch()` (key absent).
- **`studio-schema.adoc`**: documents all three `@FixedSchema` attributes in a reference table.

Studio-side wiring (`ElementParameterCreator` + `IValueChangedListener`) is out of scope for this PR and will be handled in a follow-up ticket in the Studio repository.

### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool

[QTDI-2862]: https://qlik-dev.atlassian.net/browse/QTDI-2862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ