### PR TITLE
fix:(QTDI-3280): Deploy to internal Nexus before Sonatype and bound Sonatype deploy with timeout

### DIFF
--- a/.github/workflows/jenkinsfile-check.yml
+++ b/.github/workflows/jenkinsfile-check.yml
@@ -12,7 +12,7 @@ jobs:
   brace-balance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check brace and parenthesis balance
         run: |
           open_braces=$(grep -o '{' Jenkinsfile | wc -l)

--- a/.github/workflows/jenkinsfile-check.yml
+++ b/.github/workflows/jenkinsfile-check.yml
@@ -1,0 +1,35 @@
+name: Jenkinsfile syntax check
+
+on:
+  push:
+    paths:
+      - 'Jenkinsfile'
+  pull_request:
+    paths:
+      - 'Jenkinsfile'
+
+jobs:
+  brace-balance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check brace and parenthesis balance
+        run: |
+          open_braces=$(grep -o '{' Jenkinsfile | wc -l)
+          close_braces=$(grep -o '}' Jenkinsfile | wc -l)
+          open_parens=$(grep -o '(' Jenkinsfile | wc -l)
+          close_parens=$(grep -o ')' Jenkinsfile | wc -l)
+
+          echo "Braces: $open_braces open / $close_braces close"
+          echo "Parens: $open_parens open / $close_parens close"
+
+          status=0
+          if [ "$open_braces" -ne "$close_braces" ]; then
+            echo "::error file=Jenkinsfile::Unbalanced braces: $open_braces '{' vs $close_braces '}'"
+            status=1
+          fi
+          if [ "$open_parens" -ne "$close_parens" ]; then
+            echo "::error file=Jenkinsfile::Unbalanced parentheses: $open_parens '(' vs $close_parens ')'"
+            status=1
+          fi
+          exit $status

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -454,22 +454,10 @@ pipeline {
         }
       }
       steps {
-        script {
-          withCredentials([ossrhCredentials,
-                           gpgCredentials,
-                           nexusCredentials]) {
-            sh """\
-              #!/usr/bin/env bash
-              set -xe
-              bash mvn deploy $deployOptions \
-                              $extraBuildParams \
-                              --settings .jenkins/settings.xml
-              """.stripIndent()
-          }
-        }
-        // Also deploy to internal Nexus on master/maintenance builds so that
+        // Deploy to internal Nexus first on master/maintenance builds so that
         // connectors-se Jenkins agents (which cannot reach central.sonatype.com)
-        // can resolve SNAPSHOT dependencies.
+        // can resolve SNAPSHOT dependencies as soon as possible, regardless of
+        // whether the Sonatype deploy below is slow or times out.
         script {
           if (stdBranch_buildOnly) {
             withCredentials([nexusCredentials]) {
@@ -480,6 +468,27 @@ pipeline {
                             ${extraBuildParams} \
                             --settings .jenkins/settings.xml
                 """.stripIndent()
+            }
+          }
+        }
+        // Sonatype/OSSRH deploy has a history of being slow/unreliable and can
+        // otherwise consume the whole pipeline timeout; bound it to its own
+        // timeout and degrade to UNSTABLE instead of failing the build outright
+        // (the internal Nexus deploy above already unblocks downstream consumers).
+        script {
+          timeout(time: 60, unit: 'MINUTES') {
+            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+              withCredentials([ossrhCredentials,
+                               gpgCredentials,
+                               nexusCredentials]) {
+                sh """\
+                  #!/usr/bin/env bash
+                  set -xe
+                  bash mvn deploy $deployOptions \
+                                  $extraBuildParams \
+                                  --settings .jenkins/settings.xml
+                  """.stripIndent()
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -446,7 +446,31 @@ pipeline {
         }
       }
     }
-    stage('Maven deploy') {
+    stage('Maven deploy - Nexus') {
+      // Deploy to internal Nexus first on master/maintenance builds so that
+      // connectors-se Jenkins agents (which cannot reach central.sonatype.com)
+      // can resolve SNAPSHOT dependencies as soon as possible, independent of
+      // whether the Sonatype deploy stage below is slow or times out.
+      when {
+        expression { stdBranch_buildOnly }
+      }
+      steps {
+        withCredentials([nexusCredentials]) {
+          sh """\
+            #!/usr/bin/env bash
+            set -xe
+            mvn deploy ${nexusDeployOptions} \
+                        ${extraBuildParams} \
+                        --settings .jenkins/settings.xml
+            """.stripIndent()
+        }
+      }
+    }
+    stage('Maven deploy - Sonatype') {
+      // Sonatype/OSSRH deploy has a history of being slow/unreliable and can
+      // otherwise consume the whole pipeline timeout; bound it to its own
+      // timeout and degrade to UNSTABLE instead of failing the build outright
+      // (the Nexus deploy stage above already unblocks downstream consumers).
       when {
         anyOf {
           expression { stdBranch_buildOnly }
@@ -454,27 +478,6 @@ pipeline {
         }
       }
       steps {
-        // Deploy to internal Nexus first on master/maintenance builds so that
-        // connectors-se Jenkins agents (which cannot reach central.sonatype.com)
-        // can resolve SNAPSHOT dependencies as soon as possible, regardless of
-        // whether the Sonatype deploy below is slow or times out.
-        script {
-          if (stdBranch_buildOnly) {
-            withCredentials([nexusCredentials]) {
-              sh """\
-                #!/usr/bin/env bash
-                set -xe
-                mvn deploy ${nexusDeployOptions} \
-                            ${extraBuildParams} \
-                            --settings .jenkins/settings.xml
-                """.stripIndent()
-            }
-          }
-        }
-        // Sonatype/OSSRH deploy has a history of being slow/unreliable and can
-        // otherwise consume the whole pipeline timeout; bound it to its own
-        // timeout and degrade to UNSTABLE instead of failing the build outright
-        // (the internal Nexus deploy above already unblocks downstream consumers).
         script {
           timeout(time: 60, unit: 'MINUTES') {
             catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -506,20 +506,21 @@ pipeline {
       steps {
         script {
           timeout(time: 60, unit: 'MINUTES') {
-            catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-              withCredentials([ossrhCredentials,
-                               gpgCredentials,
-                               nexusCredentials]) {
-                sh """\
-                  #!/usr/bin/env bash
-                  set -xe
-                  bash mvn deploy $deployOptions \
-                                  $extraBuildParams \
-                                  --settings .jenkins/settings.xml
-                  """.stripIndent()
-              }
-            }
-          }
+catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+  timeout(time: 60, unit: 'MINUTES') {
+    withCredentials([ossrhCredentials,
+                     gpgCredentials,
+                     nexusCredentials]) {
+      sh """\
+        #!/usr/bin/env bash
+        set -xe
+        bash mvn deploy $deployOptions \
+                        $extraBuildParams \
+                        --settings .jenkins/settings.xml
+        """.stripIndent()
+    }
+  }
+}
         }
         // Add description to job
         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,6 +252,13 @@ pipeline {
             currently published by the master branch build on both the internal Nexus
             and Sonatype/OSSRH repositories. If you do it, be sure that your branch is up to date with master.
             Only to test Jenkins job evolution, never for real development work.''')
+    booleanParam(
+        name: 'NO_SONATYPE',
+        defaultValue: false,
+        description: '''
+            DEBUG ONLY - skips the Sonatype/OSSRH deploy stage entirely, whatever the branch.
+            Use this to test the pipeline faster when the slow/unreliable Sonatype deploy
+            is not what you want to validate (e.g. only testing the internal Nexus deploy stage).''')
   }
 
   stages {
@@ -488,9 +495,12 @@ pipeline {
       // timeout and degrade to UNSTABLE instead of failing the build outright
       // (the Nexus deploy stage above already unblocks downstream consumers).
       when {
-        anyOf {
-          expression { stdBranch_buildOnly }
-          expression { devBranch_mavenDeploy }
+        allOf {
+          expression { !params.NO_SONATYPE }
+          anyOf {
+            expression { stdBranch_buildOnly }
+            expression { devBranch_mavenDeploy }
+          }
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,6 +240,18 @@ pipeline {
         name: 'JENKINS_DEBUG',
         defaultValue: false,
         description: 'Add an extra step to the pipeline allowing to keep the pod alive for debug purposes.')
+    booleanParam(
+        name: 'NO_QUALIFIER',
+        defaultValue: false,
+        description: '''
+            DEBUG ONLY - do not use on a branch that others rely on.
+            Skips the version qualifier and overwrites the branch name mechanism to run as if this were master branch,
+            so you can test Jenkins pipeline changes (e.g. the Maven deploy stages) end to end from a dev branch.
+            WARNING: the resulting artifact uses the exact same (unqualified) SNAPSHOT
+            version as master. If this build deploys, it WILL OVERWRITE the artifacts
+            currently published by the master branch build on both the internal Nexus
+            and Sonatype/OSSRH repositories. If you do it, be sure that your branch is up to date with master.
+            Only to test Jenkins job evolution, never for real development work.''')
   }
 
   stages {
@@ -275,11 +287,12 @@ pipeline {
         // Variables init
         ///////////////////////////////////////////
         script {
-          stdBranch_buildOnly = isStdBranch && params.ACTION != 'RELEASE'
+          stdBranch_buildOnly = (isStdBranch || params.NO_QUALIFIER) && params.ACTION != 'RELEASE'
           devBranch_mavenDeploy = !isStdBranch && params.MAVEN_DEPLOY
           devBranch_dockerPush = !isStdBranch && params.DOCKER_PUSH
 
-          needQualify = devBranch_mavenDeploy || devBranch_dockerPush
+          // NO_QUALIFIER forces the same (unqualified) version as master, see param warning
+          needQualify = (devBranch_mavenDeploy || devBranch_dockerPush) && !params.NO_QUALIFIER
 
           if (needQualify) {
             // Qualified version have to be released on talend_repository
@@ -384,6 +397,9 @@ pipeline {
                       Debug: $params.JENKINS_DEBUG  
                       Extra build args: $extraBuildParams  """.stripIndent()
           JenkinsStatusController.jobDescriptionAppend(description)
+          if (params.NO_QUALIFIER) {
+            JenkinsStatusController.jobDescriptionAppend("⚠️ NO_QUALIFIER debug mode: unqualified version, deploy stages forced as on master/maintenance  ")
+          }
         }
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -505,22 +505,21 @@ pipeline {
       }
       steps {
         script {
-          timeout(time: 60, unit: 'MINUTES') {
-catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
-  timeout(time: 60, unit: 'MINUTES') {
-    withCredentials([ossrhCredentials,
-                     gpgCredentials,
-                     nexusCredentials]) {
-      sh """\
-        #!/usr/bin/env bash
-        set -xe
-        bash mvn deploy $deployOptions \
-                        $extraBuildParams \
-                        --settings .jenkins/settings.xml
-        """.stripIndent()
-    }
-  }
-}
+          catchError(buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+            timeout(time: 60, unit: 'MINUTES') {
+              withCredentials([ossrhCredentials,
+                               gpgCredentials,
+                               nexusCredentials]) {
+                sh """\
+                  #!/usr/bin/env bash
+                  set -xe
+                  bash mvn deploy $deployOptions \
+                                  $extraBuildParams \
+                                  --settings .jenkins/settings.xml
+                  """.stripIndent()
+              }
+            }
+          }
         }
         // Add description to job
         script {


### PR DESCRIPTION
https://qlik-dev.atlassian.net/browse/QTDI-3280

Reorder the Maven deploy stage so the internal Nexus deploy (used by connectors build) runs first and unconditionally on master/maintenance builds, unblocking downstream consumers regardless of Sonatype deploy speed.

Wrap the Sonatype/OSSRH deploy in a 60-minute timeout with a non-fatal catchError so a slow/hanging Sonatype deploy degrades the stage to UNSTABLE instead of consuming the whole pipeline timeout and failing the build.

Added a way to test master deploy from branch with new NO_QUALIFIER parameter.

### Requirements

* Any code change adding any logic **MUST** be tested through a unit test executed with the default build
* Any API addition **MUST** be done with a documentation update if relevant 

### Why this PR is needed?

### What does this PR adds (design/code thoughts)?

### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
[x] this PR has been written with the help of GitHub Copilot or another generative AI tool
