### PR TITLE
fix(QTDI-3238): CVE-2026-59949 at.yawk.lz4:lz4-java 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -913,7 +913,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.4</version>
+        <version>1.11.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## Summary
Fixes CVE-2026-59949 (QTDI-3238) - insufficient validation of byte array arguments in JNI-based XXHash implementations in at.yawk.lz4:lz4-java allows a caller to crash the JVM.

Bumps lz4-java from 1.10.4 to 1.11.2 (the latest release on Maven Central, one patch ahead of the 1.11.1 minimum fix version - 1.11.2 also fixes CVE-2025-12183) in root pom.xml dependencyManagement (used by component-runtime-testing/component-runtime-testing-spark, singer-parent/component-kitap).

Verified with mvn dependency:tree -Dincludes=at.yawk.lz4:lz4-java in both modules - resolves to 1.11.2. Both modules hit a pre-existing, unrelated spotless-maven-plugin failure (missing talend_java_eclipse_formatter.xml resource in this worktree) reproduced identically on master without this change; mvn dependency:tree confirms the fix resolves correctly since spotless is not invoked by that goal.

Jira: https://qlik-dev.atlassian.net/browse/QTDI-3238

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [x] this PR has been written with the help of GitHub Copilot or another generative AI tool